### PR TITLE
Project covariates

### DIFF
--- a/docs/src/man/FAQ.md
+++ b/docs/src/man/FAQ.md
@@ -3,11 +3,118 @@
 
 If you do not find your problem here, or the provided solution does not solve your problem, please file an issue on [GitHub](https://github.com/OpenMendel/MendelIHT.jl/issues). 
 
-## Precompilation error
+## First-time Performance
 
-+ The first time one runs `using MendelIHT`, please do so without doing `using Distributed`. Sometimes precompilation can fail in a distributed environment. 
-+ On cluster environments, sometimes Julia crashes randomly causing core dumps. If this happens, try running Julia on intel nodes. 
+In a fresh Julia session, the first time any function gets called will take a *long* time because the code has to be compiled on the spot. For instance, compare
 
-## Parallel computing
+
+
+```julia
+@time using MendelIHT
+```
+
+      4.493948 seconds (9.04 M allocations: 564.071 MiB, 8.22% gc time)
+
+
+
+```julia
+@time using MendelIHT
+```
+
+      0.020589 seconds (32.81 k allocations: 1.886 MiB, 99.54% compilation time)
+
+
+The first call was 200 times slower than the second time! Fortunately, for large problems, compilation time becomes negligible. 
+
+## How to run code in parallel?
+
+If Julia is started with multiple threads (e.g. `julia --threads 4`), `MendelIHT.jl` will automatically run your code in parallel. 
+
 + [How to start Julia with multiple threads](https://docs.julialang.org/en/v1/manual/multi-threading/#Starting-Julia-with-multiple-threads).
-+ Execute `Threads.nthreads()` to check if multiple thread is enabled
++ Execute `Threads.nthreads()` within Julia to check if multiple thread is enabled
+
+## Phenotype quality control
+
+Our software assumes phenotypes have been properly quality controlled. For instance
+
++ There no are missing values (except possibly for Gaussian traits where we impute them with the mean). 
++ when running sparse linear regression, phenotypes should be approximately Gaussian
++ when running Poisson regression, phenotypes should have approximately equal mean and variance
++ when running multivariate traits, phenotypes are normalized
+
+...etc.
+
+Execute your judicious judgement!
+
+## When to standardize phenotypes?
+
+Only multivariate Guassian traits should be standardize to mean 0 variance 1. This ensures that mean squared error in cross-validation among traits are comparable, so the tuning process is driven by all traits.
+
+For single trait analysis, standardization is not necessary.
+
+## When to standardize covariates?
+
+**Always** standardize your covariates (genetic and non-genetic) to mean 0 variance 1. This ensures sparsity is enforced equally on all predictors. 
+
+For binary PLINK files (.bed/.bim/.fam) standardization is automatic. When using wrapper functions [cross_validate()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.cross_validate) and [iht()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.iht), non-genetic covariate will also be automatically standardized. However using internal functions [fit_iht()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.iht) and [cv_iht()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.cv_iht) bypasses standardization and is generally recommended only if wrapper functions do not work for your purposes. 
+
+## How to enforce sparsity on non-genetic covariates?
+
+The `zkeep` parameter will allow non-genetic covariates to be subject to selection. Say you have 5 covariates, and you want to always keep the first 3 in the model but possibly set the last 2 to zero. You can do
+
+
+```julia
+zkeep = trues(5)
+zkeep[4:5] .= false
+zkeep
+
+# now input zkeep as keyword argument for the wrapper or core functions, e.g. 
+# iht(plinkfile, k, d, zkeep=zkeep)
+```
+
+
+
+
+    5-element BitVector:
+     1
+     1
+     1
+     0
+     0
+
+
+
+Note `zkeep` is a `BitVector` and not a `Vector{Bool}`. 
+
+## Missing data?
+
+In general, any sample or covariate with large proportion of missing (e.g. >10%) should be excluded. But our software does have a few built-in mechanisms for handling them.
+
+**Phenotypes:** Gaussian phenotypes can be internally imputed with the mean. Binary/count phenotypes cannot be imputed.
+
+**Genotypes:** All genotypes can be imputed with the mean. 
+
+**Nongenetic covariates**: These cannot be imputed. Please impute them before running IHT.
+
+## Keyword arguments?
+
+Julia supports 2 types of "optional" arguments. Optional arguments specified before semicolon `;` can be directly inputted. Optional arguments specified after semicolon `;` needs to be explicitly inputted as `varname = x`. For instance, 
+
+
+```julia
+function add(a::Int, b::Int=1; c::Int=2)
+    return a + b + c 
+end
+@show add(0)             # 0 + b + c using default value for b, c
+@show add(0, 3)          # 0 + b + c using b = 3 and default value for c
+@show add(0, 5, c=10);   # 0 + b + c using b = 5 and c = 10
+```
+
+    add(0) = 3
+    add(0, 3) = 5
+    add(0, 5, c = 10) = 15
+
+
+## Will IHT work on sequence/imputed data?
+
+If someone can test this out and tell us, that would be extremely helpful.

--- a/docs/src/notebooks/FAQ.ipynb
+++ b/docs/src/notebooks/FAQ.ipynb
@@ -13,14 +13,188 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Precompilation error\n",
+    "## First-time Performance\n",
     "\n",
-    "+ The first time one runs `using MendelIHT`, please do so without doing `using Distributed`. Sometimes precompilation can fail in a distributed environment. \n",
-    "+ On cluster environments, sometimes Julia crashes randomly causing core dumps. If this happens, try running Julia on intel nodes. \n",
+    "In a fresh Julia session, the first time any function gets called will take a *long* time because the code has to be compiled on the spot. For instance, compare\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4.493948 seconds (9.04 M allocations: 564.071 MiB, 8.22% gc time)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@time using MendelIHT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.020589 seconds (32.81 k allocations: 1.886 MiB, 99.54% compilation time)\n"
+     ]
+    }
+   ],
+   "source": [
+    "@time using MendelIHT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first call was 200 times slower than the second time! Fortunately, for large problems, compilation time becomes negligible. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to run code in parallel?\n",
     "\n",
-    "## Parallel computing\n",
+    "If Julia is started with multiple threads (e.g. `julia --threads 4`), `MendelIHT.jl` will automatically run your code in parallel. \n",
+    "\n",
     "+ [How to start Julia with multiple threads](https://docs.julialang.org/en/v1/manual/multi-threading/#Starting-Julia-with-multiple-threads).\n",
-    "+ Execute `Threads.nthreads()` to check if multiple thread is enabled"
+    "+ Execute `Threads.nthreads()` within Julia to check if multiple thread is enabled\n",
+    "\n",
+    "## Phenotype quality control\n",
+    "\n",
+    "Our software assumes phenotypes have been properly quality controlled. For instance\n",
+    "\n",
+    "+ There no are missing values (except possibly for Gaussian traits where we impute them with the mean). \n",
+    "+ when running sparse linear regression, phenotypes should be approximately Gaussian\n",
+    "+ when running Poisson regression, phenotypes should have approximately equal mean and variance\n",
+    "+ when running multivariate traits, phenotypes are normalized\n",
+    "\n",
+    "...etc.\n",
+    "\n",
+    "Execute your judicious judgement!\n",
+    "\n",
+    "## When to standardize phenotypes?\n",
+    "\n",
+    "Only multivariate Guassian traits should be standardize to mean 0 variance 1. This ensures that mean squared error in cross-validation among traits are comparable, so the tuning process is driven by all traits.\n",
+    "\n",
+    "For single trait analysis, standardization is not necessary.\n",
+    "\n",
+    "## When to standardize covariates?\n",
+    "\n",
+    "**Always** standardize your covariates (genetic and non-genetic) to mean 0 variance 1. This ensures sparsity is enforced equally on all predictors. \n",
+    "\n",
+    "For binary PLINK files (.bed/.bim/.fam) standardization is automatic. When using wrapper functions [cross_validate()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.cross_validate) and [iht()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.iht), non-genetic covariate will also be automatically standardized. However using internal functions [fit_iht()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.iht) and [cv_iht()](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.cv_iht) bypasses standardization and is generally recommended only if wrapper functions do not work for your purposes. \n",
+    "\n",
+    "## How to enforce sparsity on non-genetic covariates?\n",
+    "\n",
+    "The `zkeep` parameter will allow non-genetic covariates to be subject to selection. Say you have 5 covariates, and you want to always keep the first 3 in the model but possibly set the last 2 to zero. You can do"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5-element BitVector:\n",
+       " 1\n",
+       " 1\n",
+       " 1\n",
+       " 0\n",
+       " 0"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zkeep = trues(5)\n",
+    "zkeep[4:5] .= false\n",
+    "zkeep\n",
+    "\n",
+    "# now input zkeep as keyword argument for the wrapper or core functions, e.g. \n",
+    "# iht(plinkfile, k, d, zkeep=zkeep)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note `zkeep` is a `BitVector` and not a `Vector{Bool}`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Missing data?\n",
+    "\n",
+    "In general, any sample or covariate with large proportion of missing (e.g. >10%) should be excluded. But our software does have a few built-in mechanisms for handling them.\n",
+    "\n",
+    "**Phenotypes:** Gaussian phenotypes can be internally imputed with the mean. Binary/count phenotypes cannot be imputed.\n",
+    "\n",
+    "**Genotypes:** All genotypes can be imputed with the mean. \n",
+    "\n",
+    "**Nongenetic covariates**: These cannot be imputed. Please impute them before running IHT.\n",
+    "\n",
+    "## Keyword arguments?\n",
+    "\n",
+    "Julia supports 2 types of \"optional\" arguments. Optional arguments specified before semicolon `;` can be directly inputted. Optional arguments specified after semicolon `;` needs to be explicitly inputted as `varname = x`. For instance, "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "add(0) = 3\n",
+      "add(0, 3) = 5\n",
+      "add(0, 5, c = 10) = 15\n"
+     ]
+    }
+   ],
+   "source": [
+    "function add(a::Int, b::Int=1; c::Int=2)\n",
+    "    return a + b + c \n",
+    "end\n",
+    "@show add(0)             # 0 + b + c using default value for b, c\n",
+    "@show add(0, 3)          # 0 + b + c using b = 3 and default value for c\n",
+    "@show add(0, 5, c=10);   # 0 + b + c using b = 5 and c = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Will IHT work on sequence/imputed data?\n",
+    "\n",
+    "If someone can test this out and tell us, that would be extremely helpful."
    ]
   }
  ],

--- a/docs/src/notebooks/examples.ipynb
+++ b/docs/src/notebooks/examples.ipynb
@@ -72,7 +72,7 @@
     "using BenchmarkTools\n",
     "\n",
     "BLAS.set_num_threads(1) # prevent over subscription with multithreading & BLAS\n",
-    "Random.seed!(1111) # set seed for reproducibility"
+    "Random.seed!(1111)      # set seed for reproducibility"
    ]
   },
   {
@@ -158,7 +158,7 @@
     {
      "data": {
       "text/plain": [
-       "17-element Vector{String}:\n",
+       "23-element Vector{String}:\n",
        " \".DS_Store\"\n",
        " \"README.md\"\n",
        " \"covariates.txt\"\n",
@@ -170,11 +170,17 @@
        " \"multivariate.bim\"\n",
        " \"multivariate.fam\"\n",
        " \"multivariate.phen\"\n",
+       " \"multivariate.trait.cov\"\n",
        " \"normal.bed\"\n",
        " \"normal.bim\"\n",
        " \"normal.fam\"\n",
        " \"normal_true_beta.txt\"\n",
        " \"phenotypes.txt\"\n",
+       " \"sim.bed\"\n",
+       " \"sim.bim\"\n",
+       " \"sim.covariates.txt\"\n",
+       " \"sim.fam\"\n",
+       " \"sim.phenotypes.txt\"\n",
        " \"simulate.jl\""
       ]
      },
@@ -207,7 +213,10 @@
    "source": [
     "### Step 1: Run cross validation to determine best model size\n",
     "\n",
-    "Here phenotypes are stored in the 6th column of `.fam` file. Other covariates are stored separately (which includes a column of 1 as intercept). Here we cross validate $k = 1,2,...20$. \n",
+    "See the [cross_validate](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.cross_validate) function API. Here, \n",
+    "+ We run 5 fold cross validation (default `q`) across k = 1, 2, ..., 20.\n",
+    "+ Phenotypes are stored in the 6th column of `.fam` file\n",
+    "+ Other covariates are stored separately (which includes a column of 1 as intercept). Here we cross validate $k = 1,2,...20$. \n",
     "\n",
     "Note the first run might take awhile because Julia needs to compile the code. "
    ]
@@ -236,7 +245,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:17\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:03\u001b[39m\n"
      ]
     },
     {
@@ -247,28 +256,28 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t1\t1383.3887888333788\n",
-      "\t2\t714.3108200438915\n",
-      "\t3\t630.5562933019421\n",
-      "\t4\t599.6952113619866\n",
-      "\t5\t438.42328589185536\n",
-      "\t6\t327.08547676403236\n",
-      "\t7\t304.1177395732532\n",
-      "\t8\t297.41346319671766\n",
-      "\t9\t227.5681066123959\n",
-      "\t10\t202.69232180491358\n",
-      "\t11\t206.35218981854467\n",
-      "\t12\t209.76930769385618\n",
-      "\t13\t213.48278746710366\n",
-      "\t14\t215.43361702847125\n",
-      "\t15\t215.6684475575618\n",
-      "\t16\t223.24291123616155\n",
-      "\t17\t221.4060678342564\n",
-      "\t18\t276.6464367814522\n",
-      "\t19\t230.976587123502\n",
-      "\t20\t268.32185480128885\n",
+      "\t1\t743.1703938637883\n",
+      "\t2\t550.1707865831861\n",
+      "\t3\t426.4937801368892\n",
+      "\t4\t336.20365731861745\n",
+      "\t5\t296.0672451743466\n",
+      "\t6\t233.02850102286234\n",
+      "\t7\t197.94215895091278\n",
+      "\t8\t199.6451087657394\n",
+      "\t9\t201.54148479914127\n",
+      "\t10\t207.96968107938025\n",
+      "\t11\t212.9172082563968\n",
+      "\t12\t215.32570044375092\n",
+      "\t13\t220.99781565117684\n",
+      "\t14\t220.78097392409862\n",
+      "\t15\t224.33931887771\n",
+      "\t16\t220.7001228820031\n",
+      "\t17\t226.6527593460433\n",
+      "\t18\t227.36164871842863\n",
+      "\t19\t237.23200258515894\n",
+      "\t20\t238.24759588500916\n",
       "\n",
-      "Best k = 10\n",
+      "Best k = 7\n",
       "\n"
      ]
     }
@@ -294,7 +303,9 @@
    "source": [
     "### Step 2: Run IHT on best k\n",
     "\n",
-    "According to cross validation, `k = 10` achieves the minimum MSE. Thus we run IHT on the full dataset."
+    "See the [iht](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.iht) function API.\n",
+    "\n",
+    "According to cross validation, `k = 7` achieves the minimum MSE. Thus we run IHT on the full dataset."
    ]
   },
   {
@@ -318,27 +329,60 @@
       "Running sparse linear regression\n",
       "Number of threads = 8\n",
       "Link functin = IdentityLink()\n",
-      "Sparsity parameter (k) = 10\n",
+      "Sparsity parameter (k) = 7\n",
       "Prior weight scaling = off\n",
       "Doubly sparse projection = off\n",
       "Debias = off\n",
       "Max IHT iterations = 200\n",
       "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -1457.8431531776794, backtracks = 0, tol = 0.7683976715709564\n",
-      "Iteration 2: loglikelihood = -1391.9907038720667, backtracks = 0, tol = 0.11226800885813881\n",
-      "Iteration 3: loglikelihood = -1390.7113887489165, backtracks = 0, tol = 0.011581483394882052\n",
-      "Iteration 4: loglikelihood = -1390.6980736000305, backtracks = 0, tol = 0.0010566984279122389\n",
-      "Iteration 5: loglikelihood = -1390.6978716629346, backtracks = 0, tol = 0.00010752965216198347\n",
-      "Iteration 6: loglikelihood = -1390.4000085563305, backtracks = 0, tol = 0.03716090961691858\n",
-      "Iteration 7: loglikelihood = -1390.3012534352063, backtracks = 0, tol = 0.0032563210092611864\n",
-      "Iteration 8: loglikelihood = -1390.300372706346, backtracks = 0, tol = 0.0003148875004358726\n",
-      "Iteration 9: loglikelihood = -1390.3003586111483, backtracks = 0, tol = 3.673233513687601e-5\n"
+      "Iteration 1: loglikelihood = -1403.6085154464329, backtracks = 0, tol = 0.8141937613701785\n",
+      "Iteration 2: loglikelihood = -1397.922430744325, backtracks = 0, tol = 0.017959863148623176\n",
+      "Iteration 3: loglikelihood = -1397.8812223841496, backtracks = 0, tol = 0.001989846075839033\n",
+      "Iteration 4: loglikelihood = -1397.8807476657355, backtracks = 0, tol = 0.00016446741159857614\n",
+      "Iteration 5: loglikelihood = -1397.8807416751808, backtracks = 0, tol = 2.0482155566893502e-5\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "IHT estimated 7 nonzero SNP predictors and 2 non-genetic predictors.\n",
+       "\n",
+       "Compute time (sec):     0.028419017791748047\n",
+       "Final loglikelihood:    -1397.8807416751808\n",
+       "SNP PVE:                0.8343751445053728\n",
+       "Iterations:             5\n",
+       "\n",
+       "Selected genetic predictors:\n",
+       "\u001b[1m7×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │     3137     0.424376\n",
+       "   2 │     4246     0.52343\n",
+       "   3 │     4717     0.922857\n",
+       "   4 │     6290    -0.677832\n",
+       "   5 │     7755    -0.542983\n",
+       "   6 │     8375    -0.792813\n",
+       "   7 │     9415    -2.17998\n",
+       "\n",
+       "Selected nongenetic predictors:\n",
+       "\u001b[1m2×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │        1     1.65223\n",
+       "   2 │        2     0.749865"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "result = iht(\"normal\", 10, Normal, covariates=\"covariates.txt\", phenotypes=6);"
+    "result = iht(\"normal\", 7, Normal, covariates=\"covariates.txt\", phenotypes=6)"
    ]
   },
   {
@@ -354,7 +398,7 @@
    "source": [
     "### Step 3: Examine results\n",
     "\n",
-    "IHT picked 8 SNPs and 2 non-genetic predictors: intercept and sex. The `Position` argument corresponds to the order in which the SNP appeared in the PLINK file, and the `Estimated_β` argument is the estimated effect size for the selected SNPs. To extract more information (for instance to extract `rs` IDs), we can do"
+    "IHT picked 7 SNPs. The `Position` argument corresponds to the order in which the SNP appeared in the PLINK file, and the `Estimated_β` argument is the estimated effect size for the selected SNPs. To extract more information (for instance to extract `rs` IDs), we can do"
    ]
   },
   {
@@ -368,18 +412,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "selected_snps = 8×6 DataFrame\n",
+      "selected_snps = 7×6 DataFrame\n",
       " Row │ chromosome  snpid    genetic_distance  position  allele1  allele2\n",
       "     │ String      String   Float64           Int64     String   String\n",
       "─────┼───────────────────────────────────────────────────────────────────\n",
-      "   1 │ 1           snp3136               0.0         1  1        2\n",
-      "   2 │ 1           snp3137               0.0         1  1        2\n",
-      "   3 │ 1           snp4246               0.0         1  1        2\n",
-      "   4 │ 1           snp4717               0.0         1  1        2\n",
-      "   5 │ 1           snp6290               0.0         1  1        2\n",
-      "   6 │ 1           snp7755               0.0         1  1        2\n",
-      "   7 │ 1           snp8375               0.0         1  1        2\n",
-      "   8 │ 1           snp9415               0.0         1  1        2\n"
+      "   1 │ 1           snp3137               0.0         1  1        2\n",
+      "   2 │ 1           snp4246               0.0         1  1        2\n",
+      "   3 │ 1           snp4717               0.0         1  1        2\n",
+      "   4 │ 1           snp6290               0.0         1  1        2\n",
+      "   5 │ 1           snp7755               0.0         1  1        2\n",
+      "   6 │ 1           snp8375               0.0         1  1        2\n",
+      "   7 │ 1           snp9415               0.0         1  1        2\n"
      ]
     }
    ],
@@ -394,9 +437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The table above displays the SNP information for the selected SNPs. Because there's only 7 causal SNPs, we have 1 false positive. \n",
-    "\n",
-    "Since data is simulated, the fields `chromosome`, `snpid`, `genetic_distance`, `position`, `allele1`, and `allele2` are fake. "
+    "The table above displays the SNP information for the selected SNPs. Because there's only 7 causal SNPs, we found all of them. The 2 non-genetic covariates represented intercept and sex, with true effect size 1.5 and 1.0. Since data is simulated, the fields `chromosome`, `snpid`, `genetic_distance`, `position`, `allele1`, and `allele2` are fake. "
    ]
   },
   {
@@ -429,7 +470,7 @@
    "source": [
     "n = 1000            # number of samples\n",
     "p = 10000           # number of SNPs\n",
-    "k = 10              # 8 causal SNPs and 2 causal covariates (intercept + sex)\n",
+    "k = 10              # 10 causal SNPs\n",
     "d = Bernoulli       # Binary (continuous) phenotypes\n",
     "l = LogitLink()     # canonical link function\n",
     "\n",
@@ -440,14 +481,14 @@
     "x = simulate_random_snparray(\"sim.bed\", n, p)\n",
     "xla = SnpLinAlg{Float64}(x, model=ADDITIVE_MODEL, center=true, scale=true, impute=true) \n",
     "\n",
-    "# nongenetic covariate: first column is the intercept, second column is sex: 0 = male 1 = female\n",
+    "# 2 nongenetic covariate: first column is the intercept, second column is sex: 0 = male 1 = female\n",
     "z = ones(n, 2) \n",
     "z[:, 2] .= rand(0:1, n)\n",
     "standardize!(@view(z[:, 2:end])) \n",
     "\n",
     "# randomly set genetic predictors where causal βᵢ ~ N(0, 1)\n",
     "true_b = zeros(p) \n",
-    "true_b[1:k-2] = randn(k-2)\n",
+    "true_b[1:k] = randn(k)\n",
     "shuffle!(true_b)\n",
     "\n",
     "# find correct position of genetic predictors\n",
@@ -516,66 +557,84 @@
       "Max IHT iterations = 200\n",
       "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -388.8910083252736, backtracks = 0, tol = 0.6418034752978493\n",
-      "Iteration 2: loglikelihood = -334.5278475827583, backtracks = 0, tol = 0.3170396015883161\n",
-      "Iteration 3: loglikelihood = -327.9633012046245, backtracks = 0, tol = 0.2025866533020331\n",
-      "Iteration 4: loglikelihood = -321.78128260006685, backtracks = 0, tol = 0.1860359951551827\n",
-      "Iteration 5: loglikelihood = -320.82291695265127, backtracks = 1, tol = 0.019411649026600777\n",
-      "Iteration 6: loglikelihood = -320.4507210246635, backtracks = 2, tol = 0.009984009889427738\n",
-      "Iteration 7: loglikelihood = -317.5178129459779, backtracks = 2, tol = 0.10991749703912314\n",
-      "Iteration 8: loglikelihood = -317.02211222442554, backtracks = 1, tol = 0.013593158611626565\n",
-      "Iteration 9: loglikelihood = -316.84609828412295, backtracks = 2, tol = 0.007169021739514612\n",
-      "Iteration 10: loglikelihood = -316.70442301799153, backtracks = 2, tol = 0.007932900581304757\n",
-      "Iteration 11: loglikelihood = -316.6123017144071, backtracks = 2, tol = 0.006753634000554562\n",
-      "Iteration 12: loglikelihood = -316.55859748055383, backtracks = 2, tol = 0.005166907901710646\n",
-      "Iteration 13: loglikelihood = -316.5276537804478, backtracks = 2, tol = 0.00394060866454871\n",
-      "Iteration 14: loglikelihood = -316.50992605296796, backtracks = 2, tol = 0.0029918249852994103\n",
-      "Iteration 15: loglikelihood = -316.4998143291673, backtracks = 2, tol = 0.002265270160216051\n",
-      "Iteration 16: loglikelihood = -316.49406613214404, backtracks = 2, tol = 0.0017110615239077592\n",
-      "Iteration 17: loglikelihood = -316.49080687297084, backtracks = 2, tol = 0.0012902536156348425\n",
-      "Iteration 18: loglikelihood = -316.4889624723853, backtracks = 2, tol = 0.0009716277317779244\n",
-      "Iteration 19: loglikelihood = -316.4879202825298, backtracks = 2, tol = 0.0007309600514247552\n",
-      "Iteration 20: loglikelihood = -316.48733204721407, backtracks = 2, tol = 0.000549484718269684\n",
-      "Iteration 21: loglikelihood = -316.4870003149547, backtracks = 2, tol = 0.0004128291474231582\n",
-      "Iteration 22: loglikelihood = -316.4868133555257, backtracks = 2, tol = 0.00031002536936769156\n",
-      "Iteration 23: loglikelihood = -316.4867080384853, backtracks = 2, tol = 0.00023274674474752565\n",
-      "Iteration 24: loglikelihood = -316.4866487332225, backtracks = 2, tol = 0.00017468833019519464\n",
-      "Iteration 25: loglikelihood = -316.486615346784, backtracks = 2, tol = 0.0001310885323519644\n",
-      "Iteration 26: loglikelihood = -316.48659655541053, backtracks = 2, tol = 9.835709203914658e-5\n"
+      "Iteration 1: loglikelihood = -410.3429870797691, backtracks = 0, tol = 0.634130944297718\n",
+      "Iteration 2: loglikelihood = -355.96269238167594, backtracks = 0, tol = 0.23373909459507045\n",
+      "Iteration 3: loglikelihood = -335.19699443343046, backtracks = 0, tol = 0.1883878956755205\n",
+      "Iteration 4: loglikelihood = -326.72483097632033, backtracks = 1, tol = 0.11662243126023769\n",
+      "Iteration 5: loglikelihood = -323.42465587337426, backtracks = 1, tol = 0.1420748329251797\n",
+      "Iteration 6: loglikelihood = -321.93583078185304, backtracks = 1, tol = 0.026234221625522528\n",
+      "Iteration 7: loglikelihood = -321.14096662573917, backtracks = 2, tol = 0.01403839948881654\n",
+      "Iteration 8: loglikelihood = -320.42084987563976, backtracks = 2, tol = 0.13238847469548456\n",
+      "Iteration 9: loglikelihood = -319.96246645074956, backtracks = 1, tol = 0.011420657379532422\n",
+      "Iteration 10: loglikelihood = -319.70632025148103, backtracks = 2, tol = 0.00906035620905566\n",
+      "Iteration 11: loglikelihood = -319.5850116168617, backtracks = 3, tol = 0.00526542665002791\n",
+      "Iteration 12: loglikelihood = -319.48907690537277, backtracks = 3, tol = 0.004636845354902531\n",
+      "Iteration 13: loglikelihood = -319.4139596352546, backtracks = 3, tol = 0.00408655714336715\n",
+      "Iteration 14: loglikelihood = -319.35538714433477, backtracks = 3, tol = 0.003602878389767637\n",
+      "Iteration 15: loglikelihood = -319.3098337852715, backtracks = 3, tol = 0.0031763270937268033\n",
+      "Iteration 16: loglikelihood = -319.2744765345821, backtracks = 3, tol = 0.0027994055509261194\n",
+      "Iteration 17: loglikelihood = -319.2470792984031, backtracks = 3, tol = 0.002466034977718209\n",
+      "Iteration 18: loglikelihood = -319.22588090965274, backtracks = 3, tol = 0.002171162642890488\n",
+      "Iteration 19: loglikelihood = -319.2094997186901, backtracks = 3, tol = 0.001910458491633558\n",
+      "Iteration 20: loglikelihood = -319.196855221667, backtracks = 3, tol = 0.0016801251066566392\n",
+      "Iteration 21: loglikelihood = -319.1871046680043, backtracks = 3, tol = 0.0014767880705742493\n",
+      "Iteration 22: loglikelihood = -319.1795922518739, backtracks = 3, tol = 0.0012974307079079153\n",
+      "Iteration 23: loglikelihood = -319.17380866099757, backtracks = 3, tol = 0.0011393509372972647\n",
+      "Iteration 24: loglikelihood = -319.16935904315795, backtracks = 3, tol = 0.0010001288849418076\n",
+      "Iteration 25: loglikelihood = -319.1659377513872, backtracks = 3, tol = 0.0008775999638190499\n",
+      "Iteration 26: loglikelihood = -319.16330850846356, backtracks = 3, tol = 0.0007698310622097819\n",
+      "Iteration 27: loglikelihood = -319.16128887828387, backtracks = 3, tol = 0.0006750988244862079\n",
+      "Iteration 28: loglikelihood = -319.1597381430372, backtracks = 3, tol = 0.0005918695947373657\n",
+      "Iteration 29: loglikelihood = -319.1585478622643, backtracks = 3, tol = 0.0005187808423979859\n",
+      "Iteration 30: loglikelihood = -319.1576345361046, backtracks = 3, tol = 0.0004546239877395596\n",
+      "Iteration 31: loglikelihood = -319.15693391434667, backtracks = 3, tol = 0.0003983285784910115\n",
+      "Iteration 32: loglikelihood = -319.1563965892339, backtracks = 3, tol = 0.000348947774612114\n",
+      "Iteration 33: loglikelihood = -319.15598458731, backtracks = 3, tol = 0.00030564509321785363\n",
+      "Iteration 34: loglikelihood = -319.15566873708605, backtracks = 3, tol = 0.0002676823575045028\n",
+      "Iteration 35: loglikelihood = -319.15542663816296, backtracks = 3, tol = 0.00023440878567259604\n",
+      "Iteration 36: loglikelihood = -319.15524109586636, backtracks = 3, tol = 0.00020525114972271962\n",
+      "Iteration 37: loglikelihood = -319.1550989157, backtracks = 3, tol = 0.00017970493004996346\n",
+      "Iteration 38: loglikelihood = -319.15498997558825, backtracks = 3, tol = 0.00015732638998333223\n",
+      "Iteration 39: loglikelihood = -319.1549065123602, backtracks = 3, tol = 0.00013772549451164306\n",
+      "Iteration 40: loglikelihood = -319.1548425732977, backtracks = 3, tol = 0.00012055959910162006\n",
+      "Iteration 41: loglikelihood = -319.15479359478843, backtracks = 3, tol = 0.00010552783734578194\n",
+      "Iteration 42: loglikelihood = -319.154756078745, backtracks = 3, tol = 9.236613986923397e-5\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "\n",
-       "IHT estimated 8 nonzero SNP predictors and 2 non-genetic predictors.\n",
+       "IHT estimated 10 nonzero SNP predictors and 2 non-genetic predictors.\n",
        "\n",
-       "Compute time (sec):     0.5662021636962891\n",
-       "Final loglikelihood:    -316.48659655541053\n",
-       "SNP PVE:                0.5592583156030205\n",
-       "Iterations:             26\n",
+       "Compute time (sec):     0.41863417625427246\n",
+       "Final loglikelihood:    -319.154756078745\n",
+       "SNP PVE:                0.5719420735919515\n",
+       "Iterations:             42\n",
        "\n",
        "Selected genetic predictors:\n",
-       "\u001b[1m8×2 DataFrame\u001b[0m\n",
+       "\u001b[1m10×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │      714    -0.7238\n",
-       "   2 │      777    -0.625216\n",
-       "   3 │     1356     1.01887\n",
-       "   4 │     2426     0.392727\n",
-       "   5 │     5080     0.395473\n",
-       "   6 │     5490    -0.720477\n",
-       "   7 │     6299    -2.09706\n",
-       "   8 │     7057     0.661431\n",
+       "   1 │      520     0.400331\n",
+       "   2 │      715    -0.663321\n",
+       "   3 │      778    -0.497369\n",
+       "   4 │     1357     1.25802\n",
+       "   5 │     3266    -0.543574\n",
+       "   6 │     5492    -0.879088\n",
+       "   7 │     5800     0.595109\n",
+       "   8 │     6049    -0.488677\n",
+       "   9 │     6301    -2.22547\n",
+       "  10 │     7059     0.797472\n",
        "\n",
        "Selected nongenetic predictors:\n",
        "\u001b[1m2×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │        1     0.919708\n",
-       "   2 │        2     1.48015"
+       "   1 │        1      1.06077\n",
+       "   2 │        2      1.41398"
       ]
      },
      "execution_count": 9,
@@ -604,15 +663,17 @@
     {
      "data": {
       "text/plain": [
-       "8×2 Matrix{Float64}:\n",
-       " -0.787272  -0.7238\n",
-       " -0.456783  -0.625216\n",
-       "  1.12735    1.01887\n",
+       "10×2 Matrix{Float64}:\n",
+       " -0.787272  -0.663321\n",
+       " -0.456783  -0.497369\n",
+       "  1.12735    1.25802\n",
+       " -0.276592  -0.543574\n",
        "  0.185925   0.0\n",
-       " -0.891023  -0.720477\n",
-       " -2.15515   -2.09706\n",
+       " -0.891023  -0.879088\n",
+       "  0.498309   0.595109\n",
+       " -2.15515   -2.22547\n",
        "  0.166931   0.0\n",
-       "  0.82265    0.661431"
+       "  0.82265    0.797472"
       ]
      },
      "execution_count": 10,
@@ -628,7 +689,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The 1st column are the true beta values, and the 2nd column is the estimated values. IHT found 6/8 genetic predictors, and estimates are reasonably close to truth. IHT missed SNPs with small effect size. With increased sample size, these small effects can be detected. The estimated non-genetic effect size is also very close to the truth (1.0 and 1.5). "
+    "**Conclusions:**\n",
+    "+ The 1st column are the true beta values, and the 2nd column is the estimated values. \n",
+    "+ IHT found 8/10 genetic predictors, and estimates are reasonably close to truth. \n",
+    "+ IHT missed SNPs with small effect size. With increased sample size, these small effects can be detected.\n",
+    "+ The estimated non-genetic effect size is also very close to the truth (1.0 and 1.5). "
    ]
   },
   {
@@ -656,7 +721,9 @@
    "source": [
     "## Example 4: Running IHT on general matrices\n",
     "\n",
-    "To run IHT on genotypes in VCF files, or other general data, one must call `fit_iht` and `cv_iht` directly. These functions are designed to work on `AbstractArray{T, 2}` type where `T` is a `Float64` or `Float32`. Thus, one must first import the data, and then call `fit_iht` and `cv_iht` on it. Note the vector of 1s (intercept) shouldn't be included in the design matrix itself, as it will be automatically included."
+    "To run IHT on genotypes in VCF files, or other general data, one must call [fit_iht](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.fit_iht) and [cv_iht](https://openmendel.github.io/MendelIHT.jl/latest/man/api/#MendelIHT.cv_iht) directly. These functions are designed to work on `AbstractArray{T, 2}` type where `T` is a `Float64` or `Float32`. \n",
+    "\n",
+    "Note the vector of 1s (intercept) shouldn't be included in the design matrix itself, as it will be automatically included."
    ]
   },
   {
@@ -742,7 +809,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:25\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:04\u001b[39m\n"
      ]
     },
     {
@@ -753,28 +820,28 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t1\t1294.4117918373186\n",
-      "\t2\t669.4092214451908\n",
-      "\t3\t543.3989940052342\n",
-      "\t4\t473.50239409691363\n",
-      "\t5\t449.5280013487634\n",
-      "\t6\t469.726620661539\n",
-      "\t7\t476.40540372697865\n",
-      "\t8\t541.741342787916\n",
-      "\t9\t539.3863798082896\n",
-      "\t10\t523.5971500146672\n",
-      "\t11\t517.4445374386203\n",
-      "\t12\t558.3509823150954\n",
-      "\t13\t600.125510865708\n",
-      "\t14\t597.7008166652079\n",
-      "\t15\t569.2744078914006\n",
-      "\t16\t603.7206875133627\n",
-      "\t17\t639.488936399919\n",
-      "\t18\t643.1761683767324\n",
-      "\t19\t646.566741795878\n",
-      "\t20\t642.7739157309286\n",
+      "\t1\t706.7023831995504\n",
+      "\t2\t563.0550969636545\n",
+      "\t3\t475.3126336967697\n",
+      "\t4\t448.33305489844025\n",
+      "\t5\t473.3927061149886\n",
+      "\t6\t475.9412876637349\n",
+      "\t7\t511.93220168171354\n",
+      "\t8\t536.4191695297267\n",
+      "\t9\t543.6710949911146\n",
+      "\t10\t546.9984660275643\n",
+      "\t11\t566.3240592279342\n",
+      "\t12\t582.0306543995698\n",
+      "\t13\t572.2797797481932\n",
+      "\t14\t555.79078283183\n",
+      "\t15\t604.8674191407598\n",
+      "\t16\t596.6516289181405\n",
+      "\t17\t620.9209742466778\n",
+      "\t18\t617.8251652635175\n",
+      "\t19\t668.4065630346416\n",
+      "\t20\t620.4559701381145\n",
       "\n",
-      "Best k = 5\n",
+      "Best k = 4\n",
       "\n"
      ]
     }
@@ -788,7 +855,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run IHT on the full dataset using the best k (achieved at k = 5)"
+    "Now run IHT on the full dataset using the best k (achieved at k = 4)"
    ]
   },
   {
@@ -812,34 +879,33 @@
       "Running sparse Poisson regression\n",
       "Number of threads = 8\n",
       "Link functin = LogLink()\n",
-      "Sparsity parameter (k) = 5\n",
+      "Sparsity parameter (k) = 4\n",
       "Prior weight scaling = off\n",
       "Doubly sparse projection = off\n",
       "Debias = off\n",
       "Max IHT iterations = 200\n",
       "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -2847.082501924986, backtracks = 0, tol = 0.2928574304111579\n",
-      "Iteration 2: loglikelihood = -2465.401434829008, backtracks = 0, tol = 0.052309994098756654\n",
-      "Iteration 3: loglikelihood = -2376.6519599956146, backtracks = 0, tol = 0.07104164424891495\n",
-      "Iteration 4: loglikelihood = -2351.583313350411, backtracks = 0, tol = 0.02620817684956463\n",
-      "Iteration 5: loglikelihood = -2343.1107828225104, backtracks = 0, tol = 0.020230016134234835\n",
-      "Iteration 6: loglikelihood = -2339.0692529047383, backtracks = 0, tol = 0.01108030835180364\n",
-      "Iteration 7: loglikelihood = -2337.149479249759, backtracks = 0, tol = 0.009309142365782066\n",
-      "Iteration 8: loglikelihood = -2336.178140295875, backtracks = 0, tol = 0.005564169436184072\n",
-      "Iteration 9: loglikelihood = -2335.6908426969235, backtracks = 0, tol = 0.004609772037770407\n",
-      "Iteration 10: loglikelihood = -2335.440388139586, backtracks = 0, tol = 0.0028617995124748164\n",
-      "Iteration 11: loglikelihood = -2335.3124548737906, backtracks = 0, tol = 0.002340881298705853\n",
-      "Iteration 12: loglikelihood = -2335.2463824561282, backtracks = 0, tol = 0.0014798329877975507\n",
-      "Iteration 13: loglikelihood = -2335.2123851939327, backtracks = 0, tol = 0.0012011066579049358\n",
-      "Iteration 14: loglikelihood = -2335.1947979604856, backtracks = 0, tol = 0.0007661746047595179\n",
-      "Iteration 15: loglikelihood = -2335.1857186752313, backtracks = 0, tol = 0.0006191995770663082\n",
-      "Iteration 16: loglikelihood = -2335.181018905229, backtracks = 0, tol = 0.00039678836835178535\n",
-      "Iteration 17: loglikelihood = -2335.1785888400173, backtracks = 0, tol = 0.0003199381492395469\n",
-      "Iteration 18: loglikelihood = -2335.1773306203627, backtracks = 0, tol = 0.00020549845888248242\n",
-      "Iteration 19: loglikelihood = -2335.1766795324024, backtracks = 0, tol = 0.00016549800033336165\n",
-      "Iteration 20: loglikelihood = -2335.176342377269, backtracks = 0, tol = 0.0001064283022001086\n",
-      "Iteration 21: loglikelihood = -2335.176167840737, backtracks = 0, tol = 8.565816720858893e-5\n"
+      "Iteration 1: loglikelihood = -2931.927168207526, backtracks = 0, tol = 0.3028304004126476\n",
+      "Iteration 2: loglikelihood = -2463.976586409181, backtracks = 0, tol = 0.05258775986537314\n",
+      "Iteration 3: loglikelihood = -2390.0609910861317, backtracks = 0, tol = 0.05578942533348056\n",
+      "Iteration 4: loglikelihood = -2360.2573652460405, backtracks = 0, tol = 0.030501089537329825\n",
+      "Iteration 5: loglikelihood = -2347.564682228364, backtracks = 0, tol = 0.021241566894705643\n",
+      "Iteration 6: loglikelihood = -2341.213319235788, backtracks = 0, tol = 0.014911500576741359\n",
+      "Iteration 7: loglikelihood = -2338.1595979203516, backtracks = 0, tol = 0.009977646130123972\n",
+      "Iteration 8: loglikelihood = -2336.62260487827, backtracks = 0, tol = 0.007575531231741733\n",
+      "Iteration 9: loglikelihood = -2335.880219053057, backtracks = 0, tol = 0.004805807684709317\n",
+      "Iteration 10: loglikelihood = -2335.5141435762675, backtracks = 0, tol = 0.0037615233194204824\n",
+      "Iteration 11: loglikelihood = -2335.3385905823416, backtracks = 0, tol = 0.002308369328965646\n",
+      "Iteration 12: loglikelihood = -2335.253553769631, backtracks = 0, tol = 0.0018289326626755682\n",
+      "Iteration 13: loglikelihood = -2335.213007797983, backtracks = 0, tol = 0.0011024772411982043\n",
+      "Iteration 14: loglikelihood = -2335.193580900639, backtracks = 0, tol = 0.0008779579192619493\n",
+      "Iteration 15: loglikelihood = -2335.1843486179923, backtracks = 0, tol = 0.0005244723959117778\n",
+      "Iteration 16: loglikelihood = -2335.1799508662666, backtracks = 0, tol = 0.00041859562583677315\n",
+      "Iteration 17: loglikelihood = -2335.177864471046, backtracks = 0, tol = 0.0002489580169555706\n",
+      "Iteration 18: loglikelihood = -2335.1768735313717, backtracks = 0, tol = 0.0001989010930461795\n",
+      "Iteration 19: loglikelihood = -2335.1764038008278, backtracks = 0, tol = 0.00011804464492615356\n",
+      "Iteration 20: loglikelihood = -2335.176181018449, backtracks = 0, tol = 9.43540926080076e-5\n"
      ]
     },
     {
@@ -848,27 +914,27 @@
        "\n",
        "IHT estimated 4 nonzero SNP predictors and 1 non-genetic predictors.\n",
        "\n",
-       "Compute time (sec):     0.2328169345855713\n",
-       "Final loglikelihood:    -2335.176167840737\n",
-       "SNP PVE:                0.09113449276174614\n",
-       "Iterations:             21\n",
+       "Compute time (sec):     0.11140608787536621\n",
+       "Final loglikelihood:    -2335.176181018449\n",
+       "SNP PVE:                0.09120222939725625\n",
+       "Iterations:             20\n",
        "\n",
        "Selected genetic predictors:\n",
        "\u001b[1m4×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │       83    -0.809284\n",
-       "   2 │      989     0.378376\n",
-       "   3 │     4294    -0.274544\n",
-       "   4 │     4459     0.169417\n",
+       "   1 │       83    -0.809399\n",
+       "   2 │      989     0.378437\n",
+       "   3 │     4294    -0.274581\n",
+       "   4 │     4459     0.16944\n",
        "\n",
        "Selected nongenetic predictors:\n",
        "\u001b[1m1×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │        1      1.26918"
+       "   1 │        1      1.26924"
       ]
      },
      "execution_count": 14,
@@ -891,13 +957,13 @@
      "data": {
       "text/plain": [
        "10×2 Matrix{Float64}:\n",
-       " -1.303      -0.809284\n",
-       "  0.585809    0.378376\n",
+       " -1.303      -0.809399\n",
+       "  0.585809    0.378437\n",
        " -0.0700563   0.0\n",
        " -0.0901341   0.0\n",
        " -0.0620201   0.0\n",
-       " -0.441452   -0.274544\n",
-       "  0.271429    0.169417\n",
+       " -0.441452   -0.274581\n",
+       "  0.271429    0.16944\n",
        " -0.164888    0.0\n",
        " -0.0790484   0.0\n",
        "  0.0829054   0.0"
@@ -917,7 +983,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since many of the true $\\beta$ are small, we were only able to find 5 true signals (4 predictors + intercept). \n",
+    "Since many of the true $\\beta$ are small, we were only able to find 4 true signals (+ intercept). \n",
     "\n",
     "**Conclusion:** In this example, we ran IHT on count response with a general `Matrix{Float64}` design matrix. Since we used simulated data, we could compare IHT's estimates with the truth. "
    ]
@@ -931,7 +997,7 @@
     "In this example, we show how to include group information to perform doubly sparse projections. Here the final model would contain at most $J = 5$ groups where each group contains limited number of (prespecified) SNPs. For simplicity, we assume the sparsity parameter $k$ is known. \n",
     "\n",
     "### Data simulation\n",
-    "To illustrate the effect of group information and prior weights, we generated correlated genotype matrix according to the procedure outlined in [our paper](https://www.biorxiv.org/content/biorxiv/early/2019/11/19/697755.full.pdf). In this example, each SNP belongs to 1 of 500 disjoint groups containing 20 SNPs each; $j = 5$ distinct groups are each assigned $1,2,...,5$ causal SNPs with effect sizes randomly chosen from $\\{−0.2,0.2\\}$. In all there 15 causal SNPs.  For grouped-IHT, we assume perfect group information. That is, the selected groups containing 1∼5 causative SNPs are assigned maximum within-group sparsity $\\lambda_g = 1,2,...,5$. The remaining groups are assigned $\\lambda_g = 1$ (i.e. only 1 active predictor are allowed)."
+    "To illustrate the effect of group IHT, we generated correlated genotype matrix according to the procedure outlined in [our paper](https://www.biorxiv.org/content/biorxiv/early/2019/11/19/697755.full.pdf). In this example, each SNP belongs to 1 of 500 disjoint groups containing 20 SNPs each; $j = 5$ distinct groups are each assigned $1,2,...,5$ causal SNPs with effect sizes randomly chosen from $\\{−0.2,0.2\\}$. In all there 15 causal SNPs.  For grouped-IHT, we assume perfect group information. That is, the selected groups containing 1∼5 causative SNPs are assigned maximum within-group sparsity $\\lambda_g = 1,2,...,5$. The remaining groups are assigned $\\lambda_g = 1$ (i.e. only 1 active predictor are allowed)."
    ]
   },
   {
@@ -951,18 +1017,17 @@
     "num_blocks = Int(p / block_size) #simulation parameter\n",
     "\n",
     "# set seed\n",
-    "Random.seed!(2019)\n",
+    "Random.seed!(1234)\n",
     "\n",
     "# assign group membership\n",
     "membership = collect(1:num_blocks)\n",
-    "g = zeros(Int64, p + 1)\n",
+    "g = zeros(Int64, p)\n",
     "for i in 1:length(membership)\n",
     "    for j in 1:block_size\n",
     "        cur_row = block_size * (i - 1) + j\n",
     "        g[block_size*(i - 1) + j] = membership[i]\n",
     "    end\n",
     "end\n",
-    "g[end] = membership[end]\n",
     "\n",
     "#simulate correlated snparray\n",
     "x = simulate_correlated_snparray(\"tmp.bed\", n, p)\n",
@@ -1029,21 +1094,21 @@
       " Row │ position  correct_β  ungrouped_IHT_β  grouped_IHT_β\n",
       "     │ Int64     Float64    Float64          Float64\n",
       "─────┼─────────────────────────────────────────────────────\n",
-      "   1 │      963       -0.2        -0.21403        0.0\n",
-      "   2 │     3485       -0.2         0.0           -0.13032\n",
-      "   3 │     3487       -0.2        -0.323509      -0.225267\n",
-      "   4 │     7405        0.2         0.254196       0.260726\n",
-      "   5 │     7407       -0.2        -0.186084      -0.202747\n",
-      "   6 │     7417       -0.2        -0.190491      -0.201521\n",
-      "   7 │     9104       -0.2        -0.189195      -0.201113\n",
-      "   8 │     9110        0.2         0.192222       0.177787\n",
-      "   9 │     9118       -0.2        -0.196494      -0.189983\n",
-      "  10 │     9120        0.2         0.253254       0.248832\n",
-      "  11 │     9206       -0.2        -0.236861      -0.217945\n",
-      "  12 │     9209       -0.2        -0.198633      -0.177085\n",
-      "  13 │     9210       -0.2        -0.172682      -0.186602\n",
-      "  14 │     9211       -0.2        -0.234481      -0.23977\n",
-      "  15 │     9217        0.2         0.227397       0.217969\n",
+      "   1 │      126        0.2         0.193695       0.179699\n",
+      "   2 │     5999       -0.2        -0.238721      -0.221097\n",
+      "   3 │     6000       -0.2        -0.139758      -0.145219\n",
+      "   4 │     6344       -0.2        -0.210029      -0.204669\n",
+      "   5 │     6359        0.2         0.212363       0.220925\n",
+      "   6 │     6360       -0.2        -0.182878      -0.186936\n",
+      "   7 │     7050       -0.2        -0.203551      -0.109019\n",
+      "   8 │     7051       -0.2        -0.286369      -0.270932\n",
+      "   9 │     7058       -0.2        -0.216709       0.0\n",
+      "  10 │     7059        0.2         0.185836       0.0\n",
+      "  11 │     7188        0.2         0.0            0.136334\n",
+      "  12 │     7190       -0.2         0.0           -0.147534\n",
+      "  13 │     7192        0.2         0.173384       0.173011\n",
+      "  14 │     7195       -0.2        -0.233133      -0.225417\n",
+      "  15 │     7198        0.2         0.0            0.131244\n",
       "\n",
       "\n"
      ]
@@ -1068,7 +1133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Conclusion:** Ungroup and grouped IHT each found 1 SNP that the other didn't find.  "
+    "**Conclusion:** Grouped IHT found 1 extra SNP, but ungrouped IHT also recovered 2 SNPs that grouped IHT didn't find. "
    ]
   },
   {
@@ -1123,7 +1188,7 @@
     "y = Float64.(y);\n",
     "\n",
     "# construct weight vector\n",
-    "w = ones(p + 1)\n",
+    "w = ones(p)\n",
     "w[correct_position] .= 2.0\n",
     "one_tenth = round(Int, p/10)\n",
     "idx = rand(1:p, one_tenth)\n",
@@ -1145,16 +1210,16 @@
       " Row │ position  correct     unweighted  weighted\n",
       "     │ Int64     Float64     Float64     Float64\n",
       "─────┼─────────────────────────────────────────────\n",
-      "   1 │     1264   0.252886     0.270233   0.280652\n",
-      "   2 │     1506  -0.0939841    0.0       -0.118611\n",
-      "   3 │     4866  -0.227394    -0.233703  -0.232989\n",
-      "   4 │     5778  -0.510488    -0.507114  -0.501733\n",
-      "   5 │     5833  -0.311969    -0.324309  -0.319763\n",
+      "   1 │     1264   0.252886     0.272761   0.282661\n",
+      "   2 │     1506  -0.0939841    0.0       -0.119236\n",
+      "   3 │     4866  -0.227394    -0.242687  -0.232847\n",
+      "   4 │     5778  -0.510488    -0.512337  -0.501374\n",
+      "   5 │     5833  -0.311969    -0.327575  -0.322659\n",
       "   6 │     5956  -0.0548168    0.0        0.0\n",
       "   7 │     6378  -0.0155173    0.0        0.0\n",
       "   8 │     7007  -0.123301     0.0        0.0\n",
       "   9 │     7063   0.0183886    0.0        0.0\n",
-      "  10 │     7995  -0.102122     0.0       -0.134898\n",
+      "  10 │     7995  -0.102122    -0.118633  -0.132814\n",
       "\n",
       "\n"
      ]
@@ -1182,7 +1247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Conclusion**: weighted IHT found 2 extra predictor than non-weighted IHT."
+    "**Conclusion**: weighted IHT found 1 extra predictor than non-weighted IHT."
    ]
   },
   {
@@ -1268,16 +1333,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\t1\t0\t0\t1\t-1.4101566028647934\t-0.4675708866010868\n",
-      "2\t1\t0\t0\t1\t1.519406122085042\t-0.1521105344879844\n",
-      "3\t1\t0\t0\t1\t-5.121683111513246\t1.4417764126708223\n",
-      "4\t1\t0\t0\t1\t2.4188275607309677\t2.5303163340220953\n",
-      "5\t1\t0\t0\t1\t2.6214639873372234\t1.005904479060761\n",
-      "6\t1\t0\t0\t1\t1.0918272785956382\t2.8773472639961106\n",
-      "7\t1\t0\t0\t1\t1.6444938174059964\t-0.3561578100979898\n",
-      "8\t1\t0\t0\t1\t-1.3607927771748423\t0.049522727283193846\n",
-      "9\t1\t0\t0\t1\t-3.9917926508357624\t1.8333328019574022\n",
-      "10\t1\t0\t0\t1\t-2.494886509291137\t2.518184222337186\n"
+      "1\t1\t0\t0\t1\t0.11302744016863553\t-0.7554260335256895\n",
+      "2\t1\t0\t0\t1\t1.9891964726499531\t-0.45289178000961794\n",
+      "3\t1\t0\t0\t1\t-3.439363162809635\t1.842833018537565\n",
+      "4\t1\t0\t0\t1\t4.04029968770823\t3.4869907320499474\n",
+      "5\t1\t0\t0\t1\t2.6565963705920983\t0.8105429321467232\n",
+      "6\t1\t0\t0\t1\t-0.16399924513126818\t3.7682978263463855\n",
+      "7\t1\t0\t0\t1\t2.274455154523604\t-0.3711839247250286\n",
+      "8\t1\t0\t0\t1\t-2.0092329751410896\t-0.5206796904236644\n",
+      "9\t1\t0\t0\t1\t-3.204538512643233\t2.6179242790617323\n",
+      "10\t1\t0\t0\t1\t-3.8119298244977333\t3.212156674633338\n"
      ]
     }
    ],
@@ -1303,16 +1368,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-1.4101566028647934,-0.4675708866010868\n",
-      "1.519406122085042,-0.1521105344879844\n",
-      "-5.121683111513246,1.4417764126708223\n",
-      "2.4188275607309677,2.5303163340220953\n",
-      "2.6214639873372234,1.005904479060761\n",
-      "1.0918272785956382,2.8773472639961106\n",
-      "1.6444938174059964,-0.3561578100979898\n",
-      "-1.3607927771748423,0.049522727283193846\n",
-      "-3.9917926508357624,1.8333328019574022\n",
-      "-2.494886509291137,2.518184222337186\n"
+      "0.11302744016863553,-0.7554260335256895\n",
+      "1.9891964726499531,-0.45289178000961794\n",
+      "-3.439363162809635,1.842833018537565\n",
+      "4.04029968770823,3.4869907320499474\n",
+      "2.6565963705920983,0.8105429321467232\n",
+      "-0.16399924513126818,3.7682978263463855\n",
+      "2.274455154523604,-0.3711839247250286\n",
+      "-2.0092329751410896,-0.5206796904236644\n",
+      "-3.204538512643233,2.6179242790617323\n",
+      "-3.8119298244977333,3.212156674633338\n"
      ]
     }
    ],
@@ -1326,7 +1391,7 @@
    "source": [
     "### Run multivariate IHT\n",
     "\n",
-    "The values specified in `path` corresponds to the total number of non-zero `k` to be tested in cross validation. Since we simulated 10 true genetic predictors and 2 non-genetic predictors (an intercept term for each trait), $k_{true} = 12$. Because non-genetic covariates are not specified, an intercept with automatically be included. "
+    "The values specified in `path` corresponds to the total number of non-zero `k` to be tested in cross validation. Since we simulated 10 true genetic predictors, $k_{true} = 10$. Because non-genetic covariates are not specified, an intercept with automatically be included. "
    ]
   },
   {
@@ -1354,7 +1419,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:08\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:03\u001b[39m\n"
      ]
     },
     {
@@ -1365,28 +1430,28 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t1\t2066.2949539850247\n",
-      "\t2\t2065.448718184275\n",
-      "\t3\t1028.1142776401573\n",
-      "\t4\t891.2895081829226\n",
-      "\t5\t761.9356018442186\n",
-      "\t6\t615.9435020075197\n",
-      "\t7\t548.8271710694912\n",
-      "\t8\t538.4145437051037\n",
-      "\t9\t526.7503996446849\n",
-      "\t10\t528.2000153966353\n",
-      "\t11\t528.4124971317248\n",
-      "\t12\t523.3419138092179\n",
-      "\t13\t538.1305969330168\n",
-      "\t14\t527.5197299749807\n",
-      "\t15\t527.7948630499403\n",
-      "\t16\t531.8215074425368\n",
-      "\t17\t533.44640197685\n",
-      "\t18\t535.7714663457024\n",
-      "\t19\t540.7820708871902\n",
-      "\t20\t548.1997323593387\n",
+      "\t1\t2894.951542220578\n",
+      "\t2\t2404.2611566806236\n",
+      "\t3\t2118.3458041809804\n",
+      "\t4\t2003.0321765449573\n",
+      "\t5\t1836.0954694153666\n",
+      "\t6\t1810.8565487650512\n",
+      "\t7\t1778.2006202357584\n",
+      "\t8\t1739.5526656101028\n",
+      "\t9\t1756.8768982533495\n",
+      "\t10\t1749.0196878126512\n",
+      "\t11\t1758.6127874414663\n",
+      "\t12\t1780.6413839078918\n",
+      "\t13\t1769.9360596010902\n",
+      "\t14\t1802.66488874727\n",
+      "\t15\t1802.0456455884719\n",
+      "\t16\t1805.1748761415956\n",
+      "\t17\t1834.8654353415632\n",
+      "\t18\t1811.30688836247\n",
+      "\t19\t1809.0070993669078\n",
+      "\t20\t1813.2736422827502\n",
       "\n",
-      "Best k = 12\n",
+      "Best k = 8\n",
       "\n"
      ]
     }
@@ -1406,12 +1471,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The best MSE is achieved at $k=12$. Let's run IHT with this estimate of $k$. Similarly, there are multiple ways to do so:"
+    "The best MSE is achieved at $k=8$. Let's run IHT with this estimate of $k$. Similarly, there are multiple ways to do so:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -1431,97 +1496,89 @@
       "Running sparse Multivariate Gaussian regression\n",
       "Number of threads = 8\n",
       "Link functin = IdentityLink()\n",
-      "Sparsity parameter (k) = 12\n",
+      "Sparsity parameter (k) = 8\n",
       "Prior weight scaling = off\n",
       "Doubly sparse projection = off\n",
       "Debias = off\n",
       "Max IHT iterations = 200\n",
       "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -2376.4820296189982, backtracks = 0, tol = 0.0\n",
-      "Iteration 2: loglikelihood = -2376.479923292264, backtracks = 0, tol = 1.1257263586193733e-6\n",
-      "Iteration 3: loglikelihood = -1957.3455984022858, backtracks = 0, tol = 0.34272673055481445\n",
-      "Iteration 4: loglikelihood = -1492.3671161424047, backtracks = 0, tol = 0.25917873408698855\n",
-      "Iteration 5: loglikelihood = -1182.1735594370286, backtracks = 0, tol = 0.23675182454701588\n",
-      "Iteration 6: loglikelihood = -1173.136551480164, backtracks = 0, tol = 0.07796393235528722\n",
-      "Iteration 7: loglikelihood = -1172.0113774449553, backtracks = 1, tol = 0.011552571250170897\n",
-      "Iteration 8: loglikelihood = -1171.889593655075, backtracks = 1, tol = 0.00348271732377267\n",
-      "Iteration 9: loglikelihood = -1171.8731432400346, backtracks = 1, tol = 0.0009816062764585914\n",
-      "Iteration 10: loglikelihood = -1171.8696778652588, backtracks = 1, tol = 0.0004151796336081729\n",
-      "Iteration 11: loglikelihood = -1171.868629414193, backtracks = 1, tol = 0.00023372232580958058\n",
-      "Iteration 12: loglikelihood = -1171.868259797147, backtracks = 1, tol = 0.0001366081371933243\n",
-      "Iteration 13: loglikelihood = -1171.8681230933576, backtracks = 1, tol = 8.144197684245368e-5\n"
+      "Iteration 1: loglikelihood = -2488.6435040107954, backtracks = 0, tol = 0.7246072304337687\n",
+      "Iteration 2: loglikelihood = -2434.7808475264533, backtracks = 0, tol = 0.17873069127511898\n",
+      "Iteration 3: loglikelihood = -2433.091980726226, backtracks = 0, tol = 0.029208315165883344\n",
+      "Iteration 4: loglikelihood = -2433.0687518437962, backtracks = 0, tol = 0.0034098472530974555\n",
+      "Iteration 5: loglikelihood = -2433.067802424958, backtracks = 0, tol = 0.0009427567101978172\n",
+      "Iteration 6: loglikelihood = -2433.0677416028657, backtracks = 0, tol = 0.00025792112221606603\n",
+      "Iteration 7: loglikelihood = -2433.067737220254, backtracks = 0, tol = 7.04657718794652e-5\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "\n",
-       "Compute time (sec):     0.17782807350158691\n",
-       "Final loglikelihood:    -1171.8681230933576\n",
-       "Iterations:             13\n",
-       "Trait 1's SNP PVE:      0.8882386104054829\n",
-       "Trait 2's SNP PVE:      0.1797217149389984\n",
+       "Compute time (sec):     0.11915302276611328\n",
+       "Final loglikelihood:    -2433.067737220254\n",
+       "Iterations:             7\n",
+       "Trait 1's SNP PVE:      0.6029987163717704\n",
+       "Trait 2's SNP PVE:      0.07348235785776043\n",
        "\n",
        "Estimated trait covariance:\n",
        "\u001b[1m2×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m trait1    \u001b[0m\u001b[1m trait2    \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Float64   \u001b[0m\u001b[90m Float64   \u001b[0m\n",
        "─────┼──────────────────────\n",
-       "   1 │  0.907309  -0.131274\n",
-       "   2 │ -0.131274   1.57327\n",
+       "   1 │ 4.7186     0.0303161\n",
+       "   2 │ 0.0303161  3.72355\n",
        "\n",
        "Trait 1: IHT estimated 6 nonzero SNP predictors\n",
        "\u001b[1m6×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │      134    -0.412059\n",
-       "   2 │      442    -1.22405\n",
-       "   3 │      450    -1.5129\n",
-       "   4 │     1891    -1.45489\n",
-       "   5 │     2557     0.780163\n",
-       "   6 │     3243    -0.833766\n",
+       "   1 │      134    -0.442256\n",
+       "   2 │      442    -1.17973\n",
+       "   3 │      450    -1.48389\n",
+       "   4 │     1891    -1.44399\n",
+       "   5 │     2557     0.828121\n",
+       "   6 │     3243    -0.803224\n",
        "\n",
        "Trait 1: IHT estimated 1 non-genetic predictors\n",
        "\u001b[1m1×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │        1     -0.14915\n",
+       "   1 │        1    -0.119153\n",
        "\n",
-       "Trait 2: IHT estimated 4 nonzero SNP predictors\n",
-       "\u001b[1m4×2 DataFrame\u001b[0m\n",
+       "Trait 2: IHT estimated 2 nonzero SNP predictors\n",
+       "\u001b[1m2×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │     1014    -0.381763\n",
-       "   2 │     1570     0.183475\n",
-       "   3 │     5214     0.346505\n",
-       "   4 │     9385    -0.18681\n",
+       "   1 │     1014    -0.391318\n",
+       "   2 │     5214     0.376128\n",
        "\n",
        "Trait 2: IHT estimated 1 non-genetic predictors\n",
        "\u001b[1m1×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │        1     0.812977\n"
+       "   1 │        1     0.862081\n"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# genotypes stored in multivariate.bed and phenotypes in multivariate.phen\n",
-    "result = iht(\"multivariate\", 12, MvNormal, phenotypes=\"multivariate.phen\")\n",
+    "result = iht(\"multivariate\", 8, MvNormal, phenotypes=\"multivariate.phen\")\n",
     "\n",
     "# genotypes stored in multivariate.bed use columns 6 and 7 of .fam as phenotypes\n",
-    "# result = iht(\"multivariate\", 12, MvNormal, phenotypes=[6, 7])\n",
+    "# result = iht(\"multivariate\", 8, MvNormal, phenotypes=[6, 7])\n",
     "\n",
     "# run cross validation directly with xla and Y (note: transpose is necessary to make samples into columns)\n",
-    "# result = fit_iht(Matrix(Y'), Transpose(xla), k=12)"
+    "# result = fit_iht(Matrix(Y'), Transpose(xla), k=8)"
    ]
   },
   {
@@ -1540,7 +1597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -1549,16 +1606,16 @@
      "data": {
       "text/plain": [
        "7×2 Matrix{Float64}:\n",
-       " -0.412059  -0.388067\n",
-       " -1.22405   -1.24972\n",
-       " -1.5129    -1.53835\n",
+       " -0.442256  -0.388067\n",
+       " -1.17973   -1.24972\n",
+       " -1.48389   -1.53835\n",
        "  0.0       -0.0034339\n",
-       " -1.45489   -1.47163\n",
-       "  0.780163   0.758756\n",
-       " -0.833766  -0.847906"
+       " -1.44399   -1.47163\n",
+       "  0.828121   0.758756\n",
+       " -0.803224  -0.847906"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1572,7 +1629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 27,
    "metadata": {
     "collapsed": false
    },
@@ -1581,12 +1638,12 @@
      "data": {
       "text/plain": [
        "3×2 Matrix{Float64}:\n",
-       " -0.381763  -0.402269\n",
-       "  0.346505   0.296183\n",
+       " -0.391318  -0.402269\n",
+       "  0.376128   0.296183\n",
        "  0.0        0.125965"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1600,7 +1657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 28,
    "metadata": {
     "collapsed": false
    },
@@ -1609,11 +1666,11 @@
      "data": {
       "text/plain": [
        "2×2 Matrix{Float64}:\n",
-       " -0.14915   -0.172668\n",
-       "  0.812977   0.729135"
+       " -0.119153  -0.172668\n",
+       "  0.862081   0.729135"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1625,7 +1682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -1634,13 +1691,13 @@
      "data": {
       "text/plain": [
        "4×2 Matrix{Float64}:\n",
-       "  0.907309   0.955563\n",
-       " -0.131274  -0.0884466\n",
-       " -0.131274  -0.0884466\n",
-       "  1.57327    1.62573"
+       " 4.7186     4.96944\n",
+       " 0.0303161  0.162057\n",
+       " 0.0303161  0.162057\n",
+       " 3.72355    3.74153"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1655,10 +1712,10 @@
    "metadata": {},
    "source": [
     "**Conclusion:** \n",
-    "+ IHT found 9 true positives: 6/7 causal SNPs for trait 1, 2/3 causal SNPs for trait 2, and 1/2 intercept\n",
-    "+ Because we ran IHT with $k=12$, there are 3 false positives. \n",
+    "+ IHT found 9 true positives: 6/7 causal SNPs for trait 1 and 2/3 causal SNPs for trait 2\n",
+    "+ Estimates for non-genetic covariates are close to the true values. \n",
     "+ Estimated trait covariance matrix closely match the true covariance\n",
-    "+ The proportion of phenotypic trait variances explained by genotypes are 0.88 and 0.15."
+    "+ The proportion of phenotypic trait variances explained by genotypes are 0.6 and 0.07."
    ]
   },
   {

--- a/src/cross_validation.jl
+++ b/src/cross_validation.jl
@@ -35,6 +35,9 @@ To check if multithreading is enabled, check output of `Threads.nthreads()`.
 - `l`: A link function. The recommended link functions are `l=IdentityLink()` for
     quantitative traits, `l=LogitLink()` for binary traits, `l=LogLink()` for Poisson
     distribution, and `l=Loglink()` for NegativeBinomial distribution. 
+- `zkeep`: BitVector determining whether non-genetic covariates in `z` will be subject 
+    to sparsity constraint. `zkeep[i] = true` means covariate `i` will NOT be projected.
+    Note covariates forced in the model are not subject to sparsity constraints in `path`. 
 - `est_r`: Symbol (`:MM`, `:Newton` or `:None`) to estimate nuisance parameters for negative binomial regression
 - `group`: vector storing group membership for each predictor
 - `weight`: vector storing vector of weights containing prior knowledge on each predictor
@@ -57,6 +60,7 @@ function cv_iht(
     est_r    :: Symbol = :None,
     group    :: AbstractVector{Int} = Int[],
     weight   :: AbstractVector{T} = T[],
+    zkeep    :: BitVector = trues(size(y, 2) > 1 ? size(z, 1) : size(z, 2)),
     folds    :: AbstractVector{Int} = rand(1:q, is_multivariate(y) ? size(x, 2) : size(x, 1)),
     debias   :: Bool = false,
     verbose  :: Bool = true,
@@ -72,7 +76,7 @@ function cv_iht(
     # preallocated arrays for efficiency
     test_idx  = [falses(length(folds)) for i in 1:Threads.nthreads()]
     train_idx = [falses(length(folds)) for i in 1:Threads.nthreads()]
-    V = [initialize(x, z, y, 1, 1, d, l, group, weight, est_r, false) for i in 1:Threads.nthreads()]
+    V = [initialize(x, z, y, 1, 1, d, l, group, weight, est_r, false, zkeep) for i in 1:Threads.nthreads()]
 
     # for displaying cross validation progress
     pmeter = Progress(q * length(path), "Cross validating...")

--- a/src/data_structures.jl
+++ b/src/data_structures.jl
@@ -63,12 +63,12 @@ function IHTVariable(x::M, z::AbstractVecOrMat{T}, y::AbstractVector{T},
         throw(DimensionMismatch("row dimension of y, x, and z ($ly, $n, $m) are not equal"))
     end
 
-    if lg != (p + q) && lg != 0
-        throw(DimensionMismatch("group must have length " * string(p + q) * " but was $lg"))
+    if lg != p && lg != 0
+        throw(DimensionMismatch("group must have length $p but was $lg"))
     end 
 
-    if lw != (p + q) && lw != 0
-        throw(DimensionMismatch("weight must have length " * string(p + q) * " but was $lw"))
+    if lw != p && lw != 0
+        throw(DimensionMismatch("weight must have length $p but was $lw"))
     end
 
     if typeof(k) == Int64

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -60,7 +60,7 @@ function fit_iht(
     l         :: Link = IdentityLink(),
     group     :: AbstractVector{Int} = Int[],
     weight    :: AbstractVector{T} = T[],
-    zkeep     :: BitVector = trues(size(z, 2) > 1 ? size(z, 1) : size(z, 2)),
+    zkeep     :: BitVector = trues(size(y, 2) > 1 ? size(z, 1) : size(z, 2)),
     est_r     :: Symbol = :None,
     use_maf   :: Bool = false, 
     debias    :: Bool = false,

--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -105,14 +105,14 @@ function _iht_gradstep!(v::mIHTVariable, η::Float)
 end
 
 function project_k!(v::mIHTVariable)
-    # store complete beta [v.b v.c] in full_b 
-    vectorize!(v.full_b, v.B, v.C)
+    # store complete beta [v.b v.c] in full_b, potentially replacing v.C with Inf 
+    vectorize!(v.full_b, v.B, v.C, v.zkeep)
 
-    # project vectorized beta to sparsity
-    project_k!(v.full_b, v.k)
+    # project to sparsity: keeping k + number of nongentic covariates
+    project_k!(v.full_b, v.k + v.zkeepn)
 
     # save model after projection
-    unvectorize!(v.full_b, v.B, v.C)
+    unvectorize!(v.full_b, v.B, v.C, v.zkeep)
 
     # if more than k entries are selected per column, randomly choose k of them
     _choose!(v)
@@ -129,17 +129,32 @@ end
     vectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix)
 
 Without allocations, copies `vec(B)` into `a` and the copies `vec(C)` into
-remaining parts of `a`.
+remaining parts of `a`. 
+
+`Ckeep` tracks entries of `C` that will not be projected. That is, entries of `a`
+corresponding to entries in `C[:, i]` will be filled with `Inf` if `Ckeep[i] = true`.
 """
-function vectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix)
+function vectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix, Ckeep::BitVector)
+    size(C, 2) == length(Ckeep) ||
+        error("size(C, 2) = $(size(C, 2)) and length(Ckeep) = $(length(Ckeep)) are different!")
     i = 1
     @inbounds @simd for j in eachindex(B)
         a[i] = B[j]
         i += 1
     end
-    @inbounds @simd for j in eachindex(C)
-        a[i] = C[j]
-        i += 1
+    m = typemax(eltype(a))
+    for j in 1:size(C, 2)
+        if Ckeep[j]
+            @inbounds @simd for l in 1:size(C, 1)
+                a[i] = m
+                i += 1
+            end
+        else
+            @inbounds @simd for l in 1:size(C, 1)
+                a[i] = C[l, j]
+                i += 1
+            end
+        end
     end
     return nothing
 end
@@ -149,16 +164,25 @@ end
 
 Without allocations, copies the first `length(vec(B))` part of `a` into `B` 
 and the remaining parts of `a` into `C`.
+
+`Ckeep` tracks entries of `C` that will not be projected. That is, entries in `C[i, :]`
+will not be touched if `Ckeep[i] = true`.
 """
-function unvectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix)
+function unvectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix, Ckeep::BitVector)
+    size(C, 2) == length(Ckeep) ||
+        error("size(C, 2) = $(size(C, 2)) and length(Ckeep) = $(length(Ckeep)) are different!")
     i = 1
     @inbounds @simd for j in eachindex(B)
         B[j] = a[i]
         i += 1
     end
-    @inbounds @simd for j in eachindex(C)
-        C[j] = a[i]
-        i += 1
+    @inbounds @simd for j in 1:size(C, 2)
+        if !Ckeep[j]
+            for l in 1:size(C, 1)
+                C[l, j] = a[i]
+                i += 1
+            end
+        end
     end
     return nothing
 end
@@ -262,6 +286,9 @@ function check_covariate_supp!(v::mIHTVariable{T, M}) where {T <: Float, M}
         v.Xk = zeros(T, nzidx, n)
         v.dfidx = zeros(T, r, nzidx) # TODO ElasticArrays.jl
     end
+    @inbounds for i in eachindex(v.zkeep)
+        v.zkeep[i] && !v.idc[i] && error("A non-genetic covariate was accidentally set to 0! Shouldn't happen!")
+    end
 end
 
 """
@@ -273,11 +300,11 @@ Note: It is possible to have `≥k` non-zero entries after projection due to
 numerical errors.
 """
 function _choose!(v::mIHTVariable)
-    sparsity = v.k
+    sparsity = v.k + v.zkeepn
     B_nz = 0
     C_nz = 0
     B_nz_idx = Int[]
-    C_nz_idx = Int[]
+    C_nz_idx = Tuple{Int, Int}[]
     # find position of non-zero beta
     for i in eachindex(v.B)
         if v.B[i] != 0
@@ -285,10 +312,13 @@ function _choose!(v::mIHTVariable)
             push!(B_nz_idx, i)
         end
     end
-    for i in eachindex(v.C)
-        if v.C[i] != 0
-            C_nz += 1
-            push!(C_nz_idx, i)
+    for j in 1:size(v.C, 2)
+        v.zkeep[j] && continue
+        for i in 1:size(v.C, 1)
+            if v.C[i, j] != 0
+                C_nz += 1
+                push!(C_nz_idx, (i, j))
+            end
         end
     end
 
@@ -302,7 +332,8 @@ function _choose!(v::mIHTVariable)
                 v.B[B_nz_idx[i]] = 0
                 B_nz -= 1
             else
-                v.C[C_nz_idx[i]] = 0
+                (ii, jj) = C_nz_idx[i]
+                v.C[ii, jj] = 0
                 C_nz -= 1
             end
         end
@@ -394,9 +425,9 @@ function init_iht_indices!(v::mIHTVariable, init_beta::Bool, cv_idx::BitVector)
 
     if !init_beta
         # first `k` non-zero entries in each β are chosen based on largest gradient
-        vectorize!(v.full_b, v.df, v.df2)
-        project_k!(v.full_b, v.k)
-        unvectorize!(v.full_b, v.df, v.df2)
+        vectorize!(v.full_b, v.df, v.df2, v.zkeep)
+        project_k!(v.full_b, v.k + v.zkeepn) # project k + number of nongentic covariates to keep
+        unvectorize!(v.full_b, v.df, v.df2, v.zkeep)
 
         # compute support based on largest gradient
         update_support!(v.idx, v.df)

--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -126,7 +126,7 @@ function project_k!(v::mIHTVariable)
 end
 
 """
-    vectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix)
+    vectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix, Ckeep::BitVector)
 
 Without allocations, copies `vec(B)` into `a` and the copies `vec(C)` into
 remaining parts of `a`. 
@@ -160,7 +160,7 @@ function vectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix, Cke
 end
 
 """
-    unvectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix)
+    unvectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix, Ckeep::BitVector)
 
 Without allocations, copies the first `length(vec(B))` part of `a` into `B` 
 and the remaining parts of `a` into `C`.

--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -373,8 +373,8 @@ function init_iht_indices!(v::mIHTVariable, init_beta::Bool, cv_idx::BitVector)
     fill!(v.Xk, 0)
     fill!(v.idx, false)
     fill!(v.idx0, false)
-    fill!(v.idc, false)
-    fill!(v.idc0, false)
+    copyto!(v.idc, v.zkeep)
+    copyto!(v.idc0, v.zkeep)
     fill!(v.resid, 0)
     fill!(v.df, 0)
     fill!(v.df2, 0)
@@ -421,6 +421,7 @@ function init_iht_indices!(v::mIHTVariable, init_beta::Bool, cv_idx::BitVector)
 
     # update mean and compute score (gradient)
     update_μ!(v)
+    update_resid!(v)
     score!(v)
 
     if !init_beta

--- a/src/pve.jl
+++ b/src/pve.jl
@@ -19,8 +19,14 @@ function pve(
     return _pve(y, μ)
 end
 
-function _pve(y::AbstractVecOrMat, μ::AbstractVecOrMat)
+function _pve(y::AbstractVector, μ::AbstractVector)
     return var(μ) / var(y)
+end
+
+# each column is a trait
+function _pve(Y::AbstractMatrix, μ::AbstractMatrix)
+    size(Y, 2) == size(μ, 2) || error("Number of columns not equal in Y and μ!")
+    return [_pve(@view(Y[i, :]), @view(μ[i, :])) for i in 1:size(Y, 2)]
 end
 
 function pve(v::IHTVariable)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -402,7 +402,7 @@ function init_iht_indices!(v::IHTVariable, init_beta::Bool, cv_idx::BitVector)
             project_k!(v.full_b, v.k + v.zkeepn) # project k + number of nongentic covariates to keep
             unvectorize!(v.full_b, v.df, v.df2, v.weight, v.zkeep)
             v.idx .= v.df .!= 0
-            v.idc .= v.df2 .!= 0
+            v.idc .= v.zkeep
 
             # Choose randomly if more are selected
             _choose!(v) 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -288,9 +288,9 @@ function vectorize!(a::AbstractVector, b::AbstractVector, c::AbstractVector,
     end
 
     # don't project certain non-genetic covariates
-    @view(a[lb+1:la][ckeep]) .= typemax(eltype(a))
+    a_view = @view(a[lb+1:la])
+    @view(a_view[ckeep]) .= typemax(eltype(a))
 end
-
 
 """
     unvectorize!(a::AbstractVector, B::AbstractMatrix, C::AbstractMatrix, Ckeep::BitVector)
@@ -396,8 +396,8 @@ function init_iht_indices!(v::IHTVariable, init_beta::Bool, cv_idx::BitVector)
         if length(v.ks) == 0 # no group projection
             project_k!(v.full_b, v.k + v.zkeepn) # project k + number of nongentic covariates to keep
             unvectorize!(v.full_b, v.df, v.df2, v.weight, v.zkeep)
-            v.idx .= v.b .!= 0
-            v.idc .= v.c .!= 0
+            v.idx .= v.df .!= 0
+            v.idc .= v.df2 .!= 0
 
             # Choose randomly if more are selected
             _choose!(v) 

--- a/test/L0_reg_test.jl
+++ b/test/L0_reg_test.jl
@@ -26,9 +26,9 @@
 	@test length(result.beta) == 10000
 	@test count(!iszero, result.beta) == k
 	@test findall(!iszero, result.beta) == [2384;3352;3353;4093;5413;5609;7403;8753;9089;9132]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-1.2601335154934064, -0.26740665871958935, 
-		0.14117990315654064, 0.28997442760192266, 0.3667114534086605, -0.13719881241645873, -0.3082574702110094, 
-		0.3328995818048077, 0.9645955209824065, -0.5094675198978443])
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-1.2601406011046452, -0.2674202492177914,
+		0.1412081066471588, 0.289955803600036, 0.3666894767520663, -0.1371805027382694, -0.308254575616033,
+		0.33288147012004443, 0.9645980728400257, -0.5094607091364866])
 	@test result.c[1] ≈ -0.026283123286410772
 	@test result.k == 10
 	@test result.logl ≈ -1406.899627901812
@@ -60,13 +60,13 @@ end
 
 	@test length(result.beta) == 10000
 	@test count(!iszero, result.beta) == k
-	@test findall(!iszero, result.beta) == [1816, 2384, 2917, 5413, 7067, 8753, 8908, 9089, 9132, 9765]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [0.2927850181979294, -1.1371390185890102, 
-		-0.2735411947195354, 0.4777936460488939, -0.310486779584213, 0.41808467980710756, -0.3436991152303386,
-		0.8844652838423853, -0.5297482667320204, -0.34131839197378927])
-	@test result.c[1] ≈ 0.013569002607988524
+	@test findall(!iszero, result.beta) == [1733, 1816, 2384, 5413, 7067, 8753, 8908, 9089, 9132, 9765]
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.2788091712310063, 0.31151387193421737, 
+	-1.1283186622644128, 0.4999869530547436, -0.32685079548465007, 0.4138519813525528, -0.32779271347276445,
+	 0.8644288162088136, -0.5064840683902377, -0.3284653237251541])
+	@test result.c[1] ≈ 0.016116760859127627
 	@test result.k == 10
-	@test result.logl ≈ -490.2010219408794
+	@test result.logl ≈ -489.8564887253825
 end
 
 @testset "fit Poisson" begin
@@ -94,13 +94,13 @@ end
 	result = fit_iht(y, xla, z, J=1, k=k, d=d(), l=l)
 	@test length(result.beta) == 10000
 	@test count(!iszero, result.beta) == k
-	@test findall(!iszero, result.beta) == [2384, 2631, 3157, 5891, 8753, 8755, 8931, 9089, 9132, 9884]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.3704728719867845, 0.09550968238347861, 
-		0.1012695640714917, 0.12454842375797137, 0.10750826591937211, 0.11630352461070562, 0.12423472147439997, 
-		0.2856470190801652, -0.12495713352581836, 0.08889994853065768])
-	@test result.c[1] ≈ -0.010771749331668815
+	@test findall(!iszero, result.beta) == [298, 2384, 3157, 5891, 7067, 8753, 8755, 8931, 9089, 9132]
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [0.09820585763162126, -0.37392590916093194, 
+		0.08489568686444253, 0.11864310078500476, 0.09414834393479564, 0.10683788271304923, 0.12908044513140238, 
+		0.12019432114450958, 0.29296236678486925, -0.12813041278457823])
+	@test result.c[1] ≈ -0.011752998591789125
 	@test result.k == 10
-	@test result.logl ≈ -1294.747256187064
+	@test result.logl ≈ -1294.452369780194
 end
 
 @testset "fit NegativeBinomial" begin
@@ -129,13 +129,13 @@ end
 
 	@test length(result.beta) == 10000
 	@test count(!iszero, result.beta) == k
-	@test findall(!iszero, result.beta) == [1245; 1774; 1982; 2384; 5413; 5440; 5614; 7166; 9089; 9132;]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.13536960133758671, -0.17233491524789818, 
-		0.13127935664692003, -0.3142802598723658, 0.12254638737412701, 0.1277401870478348, 0.10421067139834642,
-		0.13187029926894303, 0.27527241210172276, -0.2019964741423514])
-	@test result.c[1] ≈ -0.04109496358855896
+	@test findall(!iszero, result.beta) == [597, 934, 1610, 1774, 2384, 5413, 5614, 8993, 9089, 9132]
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [0.08224940823109043, 0.08341097787419621, 
+	0.1012409317334749, -0.15790186573300657, -0.2927019848104549, 0.10528516175659709, 0.09574395232655965, 
+	-0.08510453836644973, 0.25998023048548063, -0.1935947191261095])
+	@test result.c[1] ≈ -0.025855871894708525
 	@test result.k == 10
-	@test result.logl ≈ -1386.95309289023
+	@test result.logl ≈ -1393.5142690674227
 end
 
 @testset "fit with non-genetic covariates" begin
@@ -235,14 +235,13 @@ end
 
     # assign group membership
     membership = collect(1:num_blocks)
-    g = zeros(Int64, p + 1)
+    g = zeros(Int64, p)
     for i in 1:length(membership)
         for j in 1:block_size
             cur_row = block_size * (i - 1) + j
             g[block_size*(i - 1) + j] = membership[i]
         end
     end
-    g[end] = membership[end]
     
     #simulate correlated snparray
     x = simulate_correlated_snparray(undef, n, p)
@@ -282,7 +281,7 @@ end
     k = 15
     ungrouped = fit_iht(y, x_float, z, J=1, k=k, d=d(), l=l)
 
-    #run IHT with groups
+    #run IHT with 5 groups each with 3 predictor
     J = 5
     k = 3
     grouped = fit_iht(y, x_float, z, J=J, k=k, d=d(), l=l, group=g)

--- a/test/L0_reg_test.jl
+++ b/test/L0_reg_test.jl
@@ -24,14 +24,14 @@
 	show(result)
 
 	@test length(result.beta) == 10000
+	@test count(!iszero, result.beta) == k
 	@test findall(!iszero, result.beta) == [2384;3352;3353;4093;5413;5609;7403;8753;9089;9132]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-1.2601406011046452;
-	 				-0.2674202492177914; 0.14120810664715883; 0.289955803600036;
-	  				0.3666894767520663; -0.1371805027382694; -0.3082545756160329;
-	  				0.3328814701200445; 0.9645980728400257; -0.5094607091364866])
-	@test result.c[1] == 0.0
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-1.2601335154934064, -0.26740665871958935, 
+		0.14117990315654064, 0.28997442760192266, 0.3667114534086605, -0.13719881241645873, -0.3082574702110094, 
+		0.3328995818048077, 0.9645955209824065, -0.5094675198978443])
+	@test result.c[1] ≈ -0.026283123286410772
 	@test result.k == 10
-	@test result.logl ≈ -1407.2533232402275
+	@test result.logl ≈ -1406.899627901812
 end
 
 @testset "fit Bernoulli" begin
@@ -59,14 +59,14 @@ end
 	result = fit_iht(y, xla, z, J=1, k=k, d=d(), l=l)
 
 	@test length(result.beta) == 10000
-	@test findall(!iszero, result.beta) == [1733;1816;2384;5413;7067;8753;8908;9089;9132;9765]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.2787326116508012;
-					  0.3113511410050774;-1.1292096054341005;0.5001816459301949;
-					 -0.32694130827328116;0.4134742776599116;-0.3275424847038566;
-					  0.8619785898062307;-0.5068258295825918;-0.32972421733995294])
-	@test result.c[1] == 0.0
+	@test count(!iszero, result.beta) == k
+	@test findall(!iszero, result.beta) == [1816, 2384, 2917, 5413, 7067, 8753, 8908, 9089, 9132, 9765]
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [0.2927850181979294, -1.1371390185890102, 
+		-0.2735411947195354, 0.4777936460488939, -0.310486779584213, 0.41808467980710756, -0.3436991152303386,
+		0.8844652838423853, -0.5297482667320204, -0.34131839197378927])
+	@test result.c[1] ≈ 0.013569002607988524
 	@test result.k == 10
-	@test result.logl ≈ -489.8770526620568
+	@test result.logl ≈ -490.2010219408794
 end
 
 @testset "fit Poisson" begin
@@ -93,15 +93,14 @@ end
 	#run result
 	result = fit_iht(y, xla, z, J=1, k=k, d=d(), l=l)
 	@test length(result.beta) == 10000
-	@test findall(!iszero, result.beta) == [298; 606; 2384; 5891; 7067; 8753; 8755; 8931; 9089; 9132]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [0.10999211487301704;
-		-0.09628969787009399; -0.3660582504298778;  0.11767397809862554;  
-		0.09686501699067837;  0.11419451741236888;  0.12373749347128933;  
-		0.11916107757737655;  0.2904980599350941; -0.12920302008477738])
-	@test result.c[1] == 0.0
+	@test count(!iszero, result.beta) == k
+	@test findall(!iszero, result.beta) == [2384, 2631, 3157, 5891, 8753, 8755, 8931, 9089, 9132, 9884]
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.3704728719867845, 0.09550968238347861, 
+		0.1012695640714917, 0.12454842375797137, 0.10750826591937211, 0.11630352461070562, 0.12423472147439997, 
+		0.2856470190801652, -0.12495713352581836, 0.08889994853065768])
+	@test result.c[1] ≈ -0.010771749331668815
 	@test result.k == 10
-	@test result.logl ≈ -1293.4456256102478
-	@test result.iter == 14
+	@test result.logl ≈ -1294.747256187064
 end
 
 @testset "fit NegativeBinomial" begin
@@ -129,15 +128,14 @@ end
 	result = fit_iht(y, xla, z, J=1, k=k, d=d(), l=l)
 
 	@test length(result.beta) == 10000
+	@test count(!iszero, result.beta) == k
 	@test findall(!iszero, result.beta) == [1245; 1774; 1982; 2384; 5413; 5440; 5614; 7166; 9089; 9132;]
-	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.13251205076442696;
-		-0.16906821875893546;  0.12865324984770152; -0.30791709019019947;  
-		0.1202449253579259; 0.12545318690748591;  0.10252799982767402;  
-		0.12937785947321034;  0.27113364351607033;-0.19797373419860373])
-	@test result.c[1] == 0.0
+	@test all(result.beta[findall(!iszero, result.beta)] .≈ [-0.13536960133758671, -0.17233491524789818, 
+		0.13127935664692003, -0.3142802598723658, 0.12254638737412701, 0.1277401870478348, 0.10421067139834642,
+		0.13187029926894303, 0.27527241210172276, -0.2019964741423514])
+	@test result.c[1] ≈ -0.04109496358855896
 	@test result.k == 10
-	@test result.logl ≈ -1387.341396480908
-	@test result.iter == 9
+	@test result.logl ≈ -1386.95309289023
 end
 
 @testset "fit with non-genetic covariates" begin
@@ -175,8 +173,49 @@ end
 
 	@test length(result.beta) == 10000
 	@test length(result.c) == 2
-	@test length(findall(!iszero, result.beta)) == 8
+	@test length(findall(!iszero, result.beta)) == 10
 	@test findall(!iszero, result.c) == [1;2]
+	@test result.k == 10
+end
+
+@testset "model selection on non-genetic covariates" begin
+	# Since my code seems to work, putting in some output as they can be verified by comparing with simulation
+
+	#simulat data with k true predictors, from distribution d and with link l.
+	n = 1000
+	p = 10000
+	k = 10
+	d = Normal
+	l = canonicallink(d())
+
+	#set random seed
+	Random.seed!(1111)
+
+	#construct SnpArraym, snpmatrix, and non genetic covariate (intercept)
+	x = simulate_random_snparray(undef, n, p)
+	xla = SnpLinAlg{Float64}(x, model=ADDITIVE_MODEL, center=true, scale=true) 
+	z = ones(n, 2) # 1st column intercept
+	z[:, 2] .= randn(n)
+
+	# define true_b and true_c
+	true_b = zeros(p)
+	true_b[1:k-2] = randn(k-2)
+	shuffle!(true_b)
+	correct_position = findall(!iszero, true_b)
+	true_c = [3.0; 0]
+
+	# simulate phenotype
+	prob = GLM.linkinv.(l, xla * true_b .+ z * true_c)
+	y = [rand(d(i)) for i in prob]
+
+	#run result, keeping only intercept
+	zkeep = convert(BitVector, [true, false])
+	result = fit_iht(y, xla, z, J=1, k=k, d=d(), l=l, zkeep = zkeep)
+
+	@test length(result.beta) == 10000
+	@test length(result.c) == 2
+	@test length(findall(!iszero, result.beta)) == 10
+	@test count(!iszero, result.c) == 1 # the 2nd covariate should be excluded
 	@test result.k == 10
 end
 

--- a/test/cv_iht_test.jl
+++ b/test/cv_iht_test.jl
@@ -22,20 +22,18 @@
     y, true_b, correct_position = simulate_random_response(xla, k, d, l)
 
     #specify path and folds
-    path = 1:20
+    path = 0:20
     q = 3
     folds = rand(1:q, size(x, 1))
 
     # cross validation routine (with debias) 
     @time debias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=true);
-    @test length(debias) == 20
+        folds=folds, verbose=true, debias=true, max_iter=10);
     @test all(debias .> 0)
 
     # cross validation routine (no debias) 
     @time nodebias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
+        folds=folds, verbose=true, debias=false, max_iter=10);
     @test all(nodebias .> 0)
 end
 
@@ -66,20 +64,18 @@ end
     y = [rand(d(i)) for i in prob]
 
     #specify path and folds
-    path = 1:20
+    path = 0:20
     q = 3
     folds = rand(1:q, size(x, 1))
 
     # cross validation routine (with debias) 
     @time debias = cv_iht(y, x, z, d=d(), l=l, path=path,
-        q=q, folds=folds, verbose=true, debias=true);
-    @test length(debias) == 20
+        q=q, folds=folds, verbose=true, debias=true, max_iter=10);
     @test all(debias .> 0.0)
 
     # cross validation routine (no debias) 
     @time nodebias = cv_iht(y, x, z, d=d(), l=l, path=path, q=q, 
-        folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
+        folds=folds, verbose=true, debias=false, max_iter=10);
     @test all(nodebias .> 0.0)
 end
 
@@ -103,20 +99,18 @@ end
 	y, true_b, correct_position = simulate_random_response(xla, k, d, l)
 
 	#specify path and folds
-    path = 1:20
+    path = 0:20
 	q = 3
 	folds = rand(1:q, size(x, 1))
 
 	# cross validation routine (with debias) 
     @time debias = cv_iht(y, xla, z, d=d(), l=l, path=path,
-        q=q, folds=folds, verbose=true, debias=true);
-    @test length(debias) == 20
+        q=q, folds=folds, verbose=true, debias=true, max_iter=10);
     @test all(debias .> 0.0)
 
 	# cross validation routine (no debias) 
     @time nodebias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
+        folds=folds, verbose=true, debias=false, max_iter=10);
     @test all(nodebias .> 0)
 end
 
@@ -147,20 +141,18 @@ end
     y = T.([rand(d(i)) for i in prob])
 
     #specify path and folds
-    path = 1:20
+    path = 0:20
     q = 3
     folds = rand(1:q, size(x, 1))
 
     # cross validation routine (with debias) 
     @time debias = cv_iht(y, x, z, d=d(), l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=true);
-    @test length(debias) == 20
+        folds=folds, verbose=true, debias=true, max_iter=10);
     @test all(debias .> 0.0)
 
     # cross validation routine (without debias) 
     @time nodebias = cv_iht(y, x, z, d=d(), l=l, path=path, q=q, 
-        folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
+        folds=folds, verbose=true, debias=false, max_iter=10);
     @test all(nodebias .> 0)
 end
 
@@ -184,20 +176,18 @@ end
     y, true_b, correct_position = simulate_random_response(xla, k, d, l)
 
     #specify path and folds
-    path = 1:20
+    path = 0:20
     q = 3
     folds = rand(1:q, size(x, 1))
 
     # cross validation routine (with debias) 
     @time debias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=true);
-    @test length(debias) == 20
+        folds=folds, verbose=true, debias=true, max_iter=10);
     @test all(debias .> 0.0)
 
     # cross validation routine (without debias) 
     @time nodebias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q, 
-        folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
+        folds=folds, verbose=true, debias=false, max_iter=10);
     @test all(nodebias .> 0)
 end
 
@@ -221,20 +211,18 @@ end
     y, true_b, correct_position = simulate_random_response(xla, k, d, l)
 
     #specify path and folds
-    path = 1:20
+    path = 0:20
     q = 3
     folds = rand(1:q, size(x, 1))
 
     # cross validation routine (with debias) 
     @time debias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q,
         folds=folds, verbose=true, debias=true);
-    @test length(debias) == 20
     @test all(debias .> 0.0)
 
     # cross validation routine (no debias) 
     @time nodebias = cv_iht(y, xla, z, d=d(), l=l, path=path, q=q,
         folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
     @test all(nodebias .> 0)
 end
 
@@ -266,21 +254,19 @@ end
     y = T.(y)
 
     #specify path and folds
-    path = 1:20
+    path = 0:20
     q = 3
     folds = rand(1:q, size(x, 1))
 
     # cross validation routine (with debias)
 	d = d(1, T(0.5)) # need Float32 for eltype of d
     @time debias = cv_iht(y, x, z, d=d, l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=true)
-    @test length(debias) == 20
+        folds=folds, verbose=true, debias=true, max_iter=10)
     @test all(debias .> 0)
 
     # cross validation routine (no debias) 
     @time nodebias = cv_iht(y, x, z, d=d, l=l, path=path, q=q,
-        folds=folds, verbose=true, debias=false);
-    @test length(nodebias) == 20
+        folds=folds, verbose=true, debias=false, max_iter=10);
     @test all(nodebias .> 0)
 end
 
@@ -307,19 +293,16 @@ end
     correct_snps = [x[1] for x in correct_position] # causal snps
     Yt = Matrix(Y'); # in MendelIHT, multivariate traits should be rows
 
-
     @test_throws DimensionMismatch cv_iht(Yt, xla)
     @test_throws DimensionMismatch cv_iht(Y, Transpose(xla))
 
     # no debias
     Random.seed!(2021)
-    @time mses = cv_iht(Yt, Transpose(xla), debias=false)
-    @test length(mses) == 20
+    @time mses = cv_iht(Yt, Transpose(xla), debias=false, max_iter=10, path=0:20)
     @test all(mses .> 0)
 
     # yes debias
     Random.seed!(2021)
-    @time mses2 = cv_iht(Yt, Transpose(xla), debias=true)
-    @test length(mses) == 20
+    @time mses2 = cv_iht(Yt, Transpose(xla), debias=true, max_iter=10, path=0:20)
     @test all(mses2 .> 0)
 end

--- a/test/multivariate.ipynb
+++ b/test/multivariate.ipynb
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -112,10 +112,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
@@ -129,122 +129,45 @@
       "****                 Please cite our paper!                     ****\n",
       "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
       "\n",
-      "Initializing β to univariate regression values...\n",
-      "...completed in 0.2 seconds.\n",
-      "\n",
-      "Running sparse Multivariate Gaussian regression\n",
-      "Number of threads = 1\n",
-      "Link functin = IdentityLink()\n",
-      "Sparsity parameter (k) = 12\n",
-      "Prior weight scaling = off\n",
-      "Doubly sparse projection = off\n",
-      "Debias = off\n",
-      "Max IHT iterations = 200\n",
-      "Converging when tol < 0.0001 and iteration ≥ 5:\n",
-      "\n",
-      "Iteration 1: loglikelihood = -2402.2354497410997, backtracks = 0, tol = 0.1760003270995461\n",
-      "Iteration 2: loglikelihood = -2401.166812310693, backtracks = 0, tol = 0.12188695986958688\n",
-      "Iteration 3: loglikelihood = -2399.8189638012554, backtracks = 1, tol = 0.020397544997525236\n",
-      "Iteration 4: loglikelihood = -2399.687435949281, backtracks = 1, tol = 0.005964363358031513\n",
-      "Iteration 5: loglikelihood = -2399.6714344723528, backtracks = 1, tol = 0.0017959075154911754\n",
-      "Iteration 6: loglikelihood = -2399.6687494886364, backtracks = 1, tol = 0.0006588428907713464\n",
-      "Iteration 7: loglikelihood = -2399.6681299033335, backtracks = 1, tol = 0.00037690471491128887\n",
-      "Iteration 8: loglikelihood = -2399.6679548087836, backtracks = 1, tol = 0.0002160618995125787\n",
-      "Iteration 9: loglikelihood = -2399.6679004728544, backtracks = 1, tol = 0.0001240088124257539\n",
-      "Iteration 10: loglikelihood = -2399.6678829424923, backtracks = 1, tol = 7.12375915456552e-5\n",
-      "  0.310383 seconds (61.85 k allocations: 160.198 MiB, 8.63% gc time)\n"
+      "Initializing β to univariate regression values...\n"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "\n",
-       "Compute time (sec):     0.09839105606079102\n",
-       "Final loglikelihood:    -2399.6678829424923\n",
-       "Iterations:             10\n",
-       "Trait 1's SNP PVE:      0.6026817214029122\n",
-       "Trait 2's SNP PVE:      0.13349178285695323\n",
-       "\n",
-       "Estimated trait covariance:\n",
-       "\u001b[1m2×2 DataFrame\u001b[0m\n",
-       "\u001b[1m Row \u001b[0m│\u001b[1m trait1      \u001b[0m\u001b[1m trait2      \u001b[0m\n",
-       "\u001b[1m     \u001b[0m│\u001b[90m Float64     \u001b[0m\u001b[90m Float64     \u001b[0m\n",
-       "─────┼──────────────────────────\n",
-       "   1 │  4.71859     -0.00358663\n",
-       "   2 │ -0.00358663   3.48276\n",
-       "\n",
-       "Trait 1: IHT estimated 6 nonzero SNP predictors\n",
-       "\u001b[1m6×2 DataFrame\u001b[0m\n",
-       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
-       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
-       "─────┼───────────────────────\n",
-       "   1 │      134    -0.442363\n",
-       "   2 │      442    -1.18046\n",
-       "   3 │      450    -1.48331\n",
-       "   4 │     1891    -1.44301\n",
-       "   5 │     2557     0.826897\n",
-       "   6 │     3243    -0.804007\n",
-       "\n",
-       "Trait 1: IHT estimated 1 non-genetic predictors\n",
-       "\u001b[1m1×2 DataFrame\u001b[0m\n",
-       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
-       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
-       "─────┼───────────────────────\n",
-       "   1 │        1    -0.119153\n",
-       "\n",
-       "Trait 2: IHT estimated 6 nonzero SNP predictors\n",
-       "\u001b[1m6×2 DataFrame\u001b[0m\n",
-       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
-       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
-       "─────┼───────────────────────\n",
-       "   1 │     1014    -0.368701\n",
-       "   2 │     1570     0.265122\n",
-       "   3 │     3774     0.217056\n",
-       "   4 │     5214     0.362197\n",
-       "   5 │     9385    -0.27608\n",
-       "   6 │     9390     0.205804\n",
-       "\n",
-       "Trait 2: IHT estimated 1 non-genetic predictors\n",
-       "\u001b[1m1×2 DataFrame\u001b[0m\n",
-       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
-       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
-       "─────┼───────────────────────\n",
-       "   1 │        1     0.862081\n"
-      ]
-     },
-     "execution_count": 98,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Yt = Matrix(Y')\n",
-    "Zt = Matrix(z')\n",
-    "ktrue = k + count(!iszero, intercepts)\n",
-    "@time result = fit_iht(Yt, Transpose(xla), Zt, k=12, init_beta=true)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  286.576 ms (60752 allocations: 160.61 MiB)\n"
+     "ename": "LoadError",
+     "evalue": "ArgumentError: invalid Array dimensions",
+     "output_type": "error",
+     "traceback": [
+      "ArgumentError: invalid Array dimensions",
+      "",
+      "Stacktrace:",
+      "  [1] Array",
+      "    @ ./boot.jl:450 [inlined]",
+      "  [2] MendelIHT.mIHTVariable(x::Transpose{Float64, SnpLinAlg{Float64}}, z::Matrix{Float64}, y::Matrix{Float64}, k::Int64, zkeep::BitVector)",
+      "    @ MendelIHT ~/.julia/dev/MendelIHT/src/data_structures.jl:199",
+      "  [3] #initialize#1",
+      "    @ ~/.julia/dev/MendelIHT/src/data_structures.jl:123 [inlined]",
+      "  [4] initialize",
+      "    @ ~/.julia/dev/MendelIHT/src/data_structures.jl:122 [inlined]",
+      "  [5] macro expansion",
+      "    @ ./timing.jl:287 [inlined]",
+      "  [6] fit_iht(y::Matrix{Float64}, x::Transpose{Float64, SnpLinAlg{Float64}}, z::Matrix{Float64}; k::Int64, J::Int64, d::ZeroMeanDiagNormal{Tuple{Base.OneTo{Int64}}}, l::IdentityLink, group::Vector{Int64}, weight::Vector{Float64}, zkeep::BitVector, est_r::Symbol, use_maf::Bool, debias::Bool, verbose::Bool, tol::Float64, max_iter::Int64, min_iter::Int64, max_step::Int64, io::IJulia.IJuliaStdio{Base.PipeEndpoint}, init_beta::Bool)",
+      "    @ MendelIHT ~/.julia/dev/MendelIHT/src/fit.jl:100",
+      "  [7] top-level scope",
+      "    @ ./timing.jl:210 [inlined]",
+      "  [8] top-level scope",
+      "    @ ./In[7]:0",
+      "  [9] eval",
+      "    @ ./boot.jl:360 [inlined]",
+      " [10] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)",
+      "    @ Base ./loading.jl:1094"
      ]
     }
    ],
    "source": [
-    "# using matrix-matrix mul\n",
     "Yt = Matrix(Y')\n",
     "Zt = Matrix(z')\n",
     "ktrue = k + count(!iszero, intercepts)\n",
-    "@btime result = fit_iht(Yt, Transpose(xla), Zt, k=12, init_beta=true, verbose=false);"
+    "@time result = fit_iht(Yt, Transpose(xla), Zt, k=0, init_beta=true)"
    ]
   },
   {
@@ -256,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -265,16 +188,16 @@
      "data": {
       "text/plain": [
        "7×2 Matrix{Float64}:\n",
-       " -0.442327  -0.388067\n",
-       " -1.18054   -1.24972\n",
-       " -1.48333   -1.53835\n",
+       " -0.442363  -0.388067\n",
+       " -1.18046   -1.24972\n",
+       " -1.48331   -1.53835\n",
        "  0.0       -0.0034339\n",
-       " -1.44299   -1.47163\n",
-       "  0.82681    0.758756\n",
-       " -0.803993  -0.847906"
+       " -1.44301   -1.47163\n",
+       "  0.826897   0.758756\n",
+       " -0.804007  -0.847906"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -288,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -297,12 +220,12 @@
      "data": {
       "text/plain": [
        "3×2 Matrix{Float64}:\n",
-       " -0.368705  -0.402269\n",
-       "  0.3622     0.296183\n",
+       " -0.368701  -0.402269\n",
+       "  0.362197   0.296183\n",
        "  0.0        0.125965"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -316,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -329,7 +252,7 @@
        "  0.862081   0.729135"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -351,12 +274,12 @@
       "text/plain": [
        "4×2 Matrix{Float64}:\n",
        "  4.71859     4.96944\n",
-       " -0.00360313  0.162057\n",
-       " -0.00360313  0.162057\n",
+       " -0.00358663  0.162057\n",
+       " -0.00358663  0.162057\n",
        "  3.48276     3.74153"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -387,7 +310,7 @@
        " 5214"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -408,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -419,7 +342,7 @@
        "1"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -452,7 +375,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:12\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:14\u001b[39m\n"
      ]
     },
     {
@@ -463,6 +386,7 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
+      "\t0\t3197.050276401111\n",
       "\t1\t2785.5010133236\n",
       "\t2\t2382.249270184595\n",
       "\t3\t2097.8973543744823\n",
@@ -486,7 +410,7 @@
       "\n",
       "Best k = 11\n",
       "\n",
-      " 12.577238 seconds (78.85 k allocations: 323.314 MiB, 0.32% gc time)\n"
+      " 15.149703 seconds (8.15 M allocations: 744.348 MiB, 0.95% gc time)\n"
      ]
     }
    ],
@@ -494,7 +418,77 @@
     "Random.seed!(2020)\n",
     "Yt = Matrix(Y')\n",
     "Zt = Matrix(z')\n",
-    "@time mses = cv_iht(Yt, Transpose(xla), Zt, path=1:20);"
+    "@time mses = cv_iht(Yt, Transpose(xla), Zt, path=0:20, init_beta=false);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "****                   MendelIHT Version 1.4.1                  ****\n",
+      "****     Benjamin Chu, Kevin Keys, Chris German, Hua Zhou       ****\n",
+      "****   Jin Zhou, Eric Sobel, Janet Sinsheimer, Kenneth Lange    ****\n",
+      "****                                                            ****\n",
+      "****                 Please cite our paper!                     ****\n",
+      "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:26\u001b[39m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Crossvalidation Results:\n",
+      "\tk\tMSE\n",
+      "\t0\t3197.050276401111\n",
+      "\t1\t2785.4960809199397\n",
+      "\t2\t2382.246242980236\n",
+      "\t3\t2097.8954672657874\n",
+      "\t4\t1975.8677419771152\n",
+      "\t5\t1809.0806040738507\n",
+      "\t6\t1806.3766528763722\n",
+      "\t7\t1767.8668039124027\n",
+      "\t8\t1732.4558371446387\n",
+      "\t9\t1734.6916314487225\n",
+      "\t10\t1739.3711174539092\n",
+      "\t11\t1759.2677793938547\n",
+      "\t12\t1774.4168821915746\n",
+      "\t13\t1774.578320164292\n",
+      "\t14\t1774.7289649894753\n",
+      "\t15\t1792.6312493255998\n",
+      "\t16\t1833.2730465887287\n",
+      "\t17\t1813.65098766714\n",
+      "\t18\t1855.3609954310311\n",
+      "\t19\t1834.9878430150566\n",
+      "\t20\t1852.100577093223\n",
+      "\n",
+      "Best k = 8\n",
+      "\n",
+      " 26.684120 seconds (6.38 M allocations: 13.198 GiB, 4.24% gc time)\n"
+     ]
+    }
+   ],
+   "source": [
+    "Random.seed!(2020)\n",
+    "Yt = Matrix(Y')\n",
+    "Zt = Matrix(z')\n",
+    "@time mses = cv_iht(Yt, Transpose(xla), Zt, path=0:20, init_beta=true);"
    ]
   },
   {

--- a/test/multivariate.ipynb
+++ b/test/multivariate.ipynb
@@ -6,28 +6,32 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "┌ Info: Precompiling MendelIHT [921c7187-1484-5754-b919-5d3ed9ac03c4]\n",
+      "└ @ Base loading.jl:1317\n"
+     ]
+    }
+   ],
    "source": [
-    "using Distributed\n",
-    "addprocs(8)\n",
-    "\n",
-    "@everywhere begin\n",
-    "    using Revise\n",
-    "    using MendelIHT\n",
-    "    using SnpArrays\n",
-    "    using Random\n",
-    "    using GLM\n",
-    "    using DelimitedFiles\n",
-    "    using Test\n",
-    "    using Distributions\n",
-    "    using LinearAlgebra\n",
-    "    using CSV\n",
-    "    using DataFrames\n",
-    "    using StatsBase\n",
-    "    using TraitSimulation\n",
-    "    using BenchmarkTools\n",
-    "    BLAS.set_num_threads(1) # remember to set BLAS threads to 1 !!!\n",
-    "end"
+    "using Revise\n",
+    "using MendelIHT\n",
+    "using SnpArrays\n",
+    "using Random\n",
+    "using GLM\n",
+    "using DelimitedFiles\n",
+    "using Test\n",
+    "using Distributions\n",
+    "using LinearAlgebra\n",
+    "using CSV\n",
+    "using DataFrames\n",
+    "using StatsBase\n",
+    "using TraitSimulation\n",
+    "using BenchmarkTools\n",
+    "BLAS.set_num_threads(1) # remember to set BLAS threads to 1 !!!"
    ]
   },
   {
@@ -45,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 73,
    "metadata": {
     "collapsed": false
    },
@@ -73,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 74,
    "metadata": {
     "collapsed": false
    },
@@ -108,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 98,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -118,101 +122,97 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "****                   MendelIHT Version 1.4.0                  ****\n",
+      "****                   MendelIHT Version 1.4.1                  ****\n",
       "****     Benjamin Chu, Kevin Keys, Chris German, Hua Zhou       ****\n",
       "****   Jin Zhou, Eric Sobel, Janet Sinsheimer, Kenneth Lange    ****\n",
       "****                                                            ****\n",
       "****                 Please cite our paper!                     ****\n",
       "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
       "\n",
+      "Initializing β to univariate regression values...\n",
+      "...completed in 0.2 seconds.\n",
+      "\n",
       "Running sparse Multivariate Gaussian regression\n",
+      "Number of threads = 1\n",
       "Link functin = IdentityLink()\n",
       "Sparsity parameter (k) = 12\n",
       "Prior weight scaling = off\n",
       "Doubly sparse projection = off\n",
       "Debias = off\n",
       "Max IHT iterations = 200\n",
-      "Converging when tol < 0.0001:\n",
+      "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -941.0456295886843, backtracks = 0, tol = 0.0\n",
-      "Iteration 2: loglikelihood = -794.3038174354316, backtracks = 0, tol = 0.1403802175646323\n",
-      "Iteration 3: loglikelihood = -773.1339392194564, backtracks = 0, tol = 0.02590131441706482\n",
-      "Iteration 4: loglikelihood = -757.9268574865459, backtracks = 0, tol = 0.07929204824916032\n",
-      "Iteration 5: loglikelihood = -752.8639160544699, backtracks = 2, tol = 0.016093957103927192\n",
-      "Iteration 6: loglikelihood = -751.8227046545962, backtracks = 2, tol = 0.005436564691555082\n",
-      "Iteration 7: loglikelihood = -751.3772461106605, backtracks = 2, tol = 0.0023789727462613743\n",
-      "Iteration 8: loglikelihood = -751.1045749998019, backtracks = 2, tol = 0.0019925965450385227\n",
-      "Iteration 9: loglikelihood = -750.9208355183061, backtracks = 2, tol = 0.001653432622842204\n",
-      "Iteration 10: loglikelihood = -750.7960244941769, backtracks = 2, tol = 0.0013567847910469335\n",
-      "Iteration 11: loglikelihood = -750.7119668193508, backtracks = 2, tol = 0.0011024241701498396\n",
-      "Iteration 12: loglikelihood = -750.6558556348901, backtracks = 2, tol = 0.0008886911151286319\n",
-      "Iteration 13: loglikelihood = -750.618647896629, backtracks = 2, tol = 0.0007121352805476677\n",
-      "Iteration 14: loglikelihood = -750.5940871077579, backtracks = 2, tol = 0.0005682087414833574\n",
-      "Iteration 15: loglikelihood = -750.5779220754173, backtracks = 2, tol = 0.00045202299057501\n",
-      "Iteration 16: loglikelihood = -750.567301738602, backtracks = 2, tol = 0.00035888422586780223\n",
-      "Iteration 17: loglikelihood = -750.5603310555576, backtracks = 2, tol = 0.000284583536532865\n",
-      "Iteration 18: loglikelihood = -750.5557578309397, backtracks = 2, tol = 0.00022932911769187194\n",
-      "Iteration 19: loglikelihood = -750.5527577388225, backtracks = 2, tol = 0.000188981444398335\n",
-      "Iteration 20: loglikelihood = -750.5507893512, backtracks = 2, tol = 0.000155525579180965\n",
-      "Iteration 21: loglikelihood = -750.5494975022702, backtracks = 2, tol = 0.00012785128430781818\n",
-      "Iteration 22: loglikelihood = -750.5486493510793, backtracks = 2, tol = 0.00010500381848893664\n",
-      "Iteration 23: loglikelihood = -750.5480922763699, backtracks = 2, tol = 8.617113744730798e-5\n",
-      "  0.659708 seconds (63.19 k allocations: 166.748 MiB, 4.61% gc time)\n"
+      "Iteration 1: loglikelihood = -2402.2354497410997, backtracks = 0, tol = 0.1760003270995461\n",
+      "Iteration 2: loglikelihood = -2401.166812310693, backtracks = 0, tol = 0.12188695986958688\n",
+      "Iteration 3: loglikelihood = -2399.8189638012554, backtracks = 1, tol = 0.020397544997525236\n",
+      "Iteration 4: loglikelihood = -2399.687435949281, backtracks = 1, tol = 0.005964363358031513\n",
+      "Iteration 5: loglikelihood = -2399.6714344723528, backtracks = 1, tol = 0.0017959075154911754\n",
+      "Iteration 6: loglikelihood = -2399.6687494886364, backtracks = 1, tol = 0.0006588428907713464\n",
+      "Iteration 7: loglikelihood = -2399.6681299033335, backtracks = 1, tol = 0.00037690471491128887\n",
+      "Iteration 8: loglikelihood = -2399.6679548087836, backtracks = 1, tol = 0.0002160618995125787\n",
+      "Iteration 9: loglikelihood = -2399.6679004728544, backtracks = 1, tol = 0.0001240088124257539\n",
+      "Iteration 10: loglikelihood = -2399.6678829424923, backtracks = 1, tol = 7.12375915456552e-5\n",
+      "  0.310383 seconds (61.85 k allocations: 160.198 MiB, 8.63% gc time)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "\n",
-       "Compute time (sec):     0.1528639793395996\n",
-       "Final loglikelihood:    -750.5480922763699\n",
-       "Iterations:             23\n",
-       "Trait 1's SNP PVE:      0.8428856455663646\n",
-       "Trait 2's SNP PVE:      0.4162617230281456\n",
+       "Compute time (sec):     0.09839105606079102\n",
+       "Final loglikelihood:    -2399.6678829424923\n",
+       "Iterations:             10\n",
+       "Trait 1's SNP PVE:      0.6026817214029122\n",
+       "Trait 2's SNP PVE:      0.13349178285695323\n",
        "\n",
        "Estimated trait covariance:\n",
        "\u001b[1m2×2 DataFrame\u001b[0m\n",
-       "\u001b[1m Row \u001b[0m│\u001b[1m trait1    \u001b[0m\u001b[1m trait2    \u001b[0m\n",
-       "\u001b[1m     \u001b[0m│\u001b[90m Float64   \u001b[0m\u001b[90m Float64   \u001b[0m\n",
-       "─────┼──────────────────────\n",
-       "   1 │  1.4793    -0.172341\n",
-       "   2 │ -0.172341   0.430541\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m trait1      \u001b[0m\u001b[1m trait2      \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Float64     \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼──────────────────────────\n",
+       "   1 │  4.71859     -0.00358663\n",
+       "   2 │ -0.00358663   3.48276\n",
        "\n",
-       "Trait 1: IHT estimated 8 nonzero SNP predictors\n",
-       "\u001b[1m8×2 DataFrame\u001b[0m\n",
+       "Trait 1: IHT estimated 6 nonzero SNP predictors\n",
+       "\u001b[1m6×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │      134    -0.316683\n",
-       "   2 │      442    -1.23384\n",
-       "   3 │      450    -1.54167\n",
-       "   4 │     1891    -1.45618\n",
-       "   5 │     2557     0.767983\n",
-       "   6 │     3243    -0.929433\n",
-       "   7 │     6013    -0.137052\n",
-       "   8 │     6151     0.117193\n",
+       "   1 │      134    -0.442363\n",
+       "   2 │      442    -1.18046\n",
+       "   3 │      450    -1.48331\n",
+       "   4 │     1891    -1.44301\n",
+       "   5 │     2557     0.826897\n",
+       "   6 │     3243    -0.804007\n",
        "\n",
-       "Trait 1: IHT estimated 0 non-genetic predictors\n",
-       "\u001b[1m0×2 DataFrame\u001b[0m\n",
-       "\n",
-       "Trait 2: IHT estimated 3 nonzero SNP predictors\n",
-       "\u001b[1m3×2 DataFrame\u001b[0m\n",
+       "Trait 1: IHT estimated 1 non-genetic predictors\n",
+       "\u001b[1m1×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │     1014   -0.462428\n",
-       "   2 │     5214    0.284612\n",
-       "   3 │     7949    0.0993845\n",
+       "   1 │        1    -0.119153\n",
+       "\n",
+       "Trait 2: IHT estimated 6 nonzero SNP predictors\n",
+       "\u001b[1m6×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │     1014    -0.368701\n",
+       "   2 │     1570     0.265122\n",
+       "   3 │     3774     0.217056\n",
+       "   4 │     5214     0.362197\n",
+       "   5 │     9385    -0.27608\n",
+       "   6 │     9390     0.205804\n",
        "\n",
        "Trait 2: IHT estimated 1 non-genetic predictors\n",
        "\u001b[1m1×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │        1     0.754201\n"
+       "   1 │        1     0.862081\n"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 76,
    "metadata": {
     "collapsed": false
    },
@@ -235,7 +235,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  557.748 ms (61750 allocations: 166.68 MiB)\n"
+      "  286.576 ms (60752 allocations: 160.61 MiB)\n"
      ]
     }
    ],
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 77,
    "metadata": {
     "collapsed": false
    },
@@ -265,16 +265,16 @@
      "data": {
       "text/plain": [
        "7×2 Matrix{Float64}:\n",
-       " -0.316683  -0.388067\n",
-       " -1.23384   -1.24972\n",
-       " -1.54167   -1.53835\n",
+       " -0.442327  -0.388067\n",
+       " -1.18054   -1.24972\n",
+       " -1.48333   -1.53835\n",
        "  0.0       -0.0034339\n",
-       " -1.45618   -1.47163\n",
-       "  0.767983   0.758756\n",
-       " -0.929433  -0.847906"
+       " -1.44299   -1.47163\n",
+       "  0.82681    0.758756\n",
+       " -0.803993  -0.847906"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 78,
    "metadata": {
     "collapsed": false
    },
@@ -297,12 +297,12 @@
      "data": {
       "text/plain": [
        "3×2 Matrix{Float64}:\n",
-       " -0.462428   -0.402269\n",
-       "  0.284612    0.296183\n",
-       "  0.0993845   0.125965"
+       " -0.368705  -0.402269\n",
+       "  0.3622     0.296183\n",
+       "  0.0        0.125965"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 79,
    "metadata": {
     "collapsed": false
    },
@@ -325,11 +325,11 @@
      "data": {
       "text/plain": [
        "2×2 Matrix{Float64}:\n",
-       " 0.0       -0.172668\n",
-       " 0.754201   0.729135"
+       " -0.119153  -0.172668\n",
+       "  0.862081   0.729135"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 80,
    "metadata": {
     "collapsed": false
    },
@@ -350,13 +350,13 @@
      "data": {
       "text/plain": [
        "4×2 Matrix{Float64}:\n",
-       "  1.4793     1.57833\n",
-       " -0.172341  -0.156617\n",
-       " -0.172341  -0.156617\n",
-       "  0.430541   0.43058"
+       "  4.71859     4.96944\n",
+       " -0.00360313  0.162057\n",
+       " -0.00360313  0.162057\n",
+       "  3.48276     3.74153"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 81,
    "metadata": {
     "collapsed": false
    },
@@ -376,7 +376,7 @@
     {
      "data": {
       "text/plain": [
-       "9-element Vector{Int64}:\n",
+       "8-element Vector{Int64}:\n",
        "  134\n",
        "  442\n",
        "  450\n",
@@ -384,11 +384,10 @@
        " 2557\n",
        " 3243\n",
        " 1014\n",
-       " 5214\n",
-       " 7949"
+       " 5214"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,16 +408,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 101,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Threads.nthreads()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "****                   MendelIHT Version 1.4.1                  ****\n",
+      "****     Benjamin Chu, Kevin Keys, Chris German, Hua Zhou       ****\n",
+      "****   Jin Zhou, Eric Sobel, Janet Sinsheimer, Kenneth Lange    ****\n",
+      "****                                                            ****\n",
+      "****                 Please cite our paper!                     ****\n",
+      "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
+      "\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:01:49\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:12\u001b[39m\n"
      ]
     },
     {
@@ -429,30 +463,30 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t1\t1964.8539525289493\n",
-      "\t2\t1963.1872007338732\n",
-      "\t3\t1916.8142825915036\n",
-      "\t4\t1664.633986139634\n",
-      "\t5\t1076.2797767637928\n",
-      "\t6\t740.8603760569093\n",
-      "\t7\t639.8845864616464\n",
-      "\t8\t629.8607230683073\n",
-      "\t9\t628.6091353498907\n",
-      "\t10\t414.172981593151\n",
-      "\t11\t404.6464118074338\n",
-      "\t12\t407.32827941907664\n",
-      "\t13\t408.5761872323272\n",
-      "\t14\t416.38756112570246\n",
-      "\t15\t414.40679106931645\n",
-      "\t16\t413.4783079837213\n",
-      "\t17\t414.1882003926461\n",
-      "\t18\t422.40447837594587\n",
-      "\t19\t426.3279575184899\n",
-      "\t20\t424.2708844036919\n",
+      "\t1\t2785.5010133236\n",
+      "\t2\t2382.249270184595\n",
+      "\t3\t2097.8973543744823\n",
+      "\t4\t1975.867901548581\n",
+      "\t5\t1809.0805620608676\n",
+      "\t6\t1806.39486890902\n",
+      "\t7\t1776.8736737055538\n",
+      "\t8\t1756.6114229233608\n",
+      "\t9\t1758.7156108647926\n",
+      "\t10\t1758.6669076439284\n",
+      "\t11\t1753.7462845761318\n",
+      "\t12\t1778.5120850213254\n",
+      "\t13\t1765.1006203482223\n",
+      "\t14\t1781.2997877319665\n",
+      "\t15\t1783.3267519956285\n",
+      "\t16\t1810.6396785779898\n",
+      "\t17\t1795.7103455642555\n",
+      "\t18\t1829.1524569312926\n",
+      "\t19\t1806.8456952013657\n",
+      "\t20\t1833.0931393632602\n",
       "\n",
       "Best k = 11\n",
       "\n",
-      "110.056685 seconds (49.28 k allocations: 9.624 MiB)\n"
+      " 12.577238 seconds (78.85 k allocations: 323.314 MiB, 0.32% gc time)\n"
      ]
     }
    ],
@@ -464,97 +498,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:07:06\u001b[39m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "Crossvalidation Results:\n",
-      "\tk\tMSE\n",
-      "\t1\t1964.8539525289493\n",
-      "\t2\t1963.1872007338732\n",
-      "\t3\t1916.8142825915036\n",
-      "\t4\t1664.633986139634\n",
-      "\t5\t1076.2797767637928\n",
-      "\t6\t740.8603760569093\n",
-      "\t7\t639.8845864616464\n",
-      "\t8\t629.8607230683073\n",
-      "\t9\t628.6091353498907\n",
-      "\t10\t414.172981593151\n",
-      "\t11\t404.6464118074338\n",
-      "\t12\t407.32827941907664\n",
-      "\t13\t408.5761872323272\n",
-      "\t14\t416.38756112570246\n",
-      "\t15\t414.40679106931645\n",
-      "\t16\t413.4783079837213\n",
-      "\t17\t414.1882003926461\n",
-      "\t18\t422.40447837594587\n",
-      "\t19\t426.3279575184899\n",
-      "\t20\t424.2708844036919\n",
-      "\t21\t427.92372077209626\n",
-      "\t22\t426.5310783334769\n",
-      "\t23\t431.58448976647367\n",
-      "\t24\t428.84906223839783\n",
-      "\t25\t430.7459922290462\n",
-      "\t26\t431.70517591918394\n",
-      "\t27\t432.23349943600556\n",
-      "\t28\t437.5456807542665\n",
-      "\t29\t439.58162504249174\n",
-      "\t30\t440.6668481497559\n",
-      "\t31\t439.6536144905261\n",
-      "\t32\t442.13196123578916\n",
-      "\t33\t439.7253703435178\n",
-      "\t34\t437.35727877696576\n",
-      "\t35\t445.9093617671116\n",
-      "\t36\t446.13320267575125\n",
-      "\t37\t448.03026665210984\n",
-      "\t38\t448.85316898659295\n",
-      "\t39\t455.3535904841336\n",
-      "\t40\t454.8148210614329\n",
-      "\t41\t454.0234718365199\n",
-      "\t42\t455.3905909021192\n",
-      "\t43\t459.7264593035689\n",
-      "\t44\t505.24742369913986\n",
-      "\t45\t453.7668798094988\n",
-      "\t46\t460.61115159393387\n",
-      "\t47\t456.39491057349727\n",
-      "\t48\t456.8766166872476\n",
-      "\t49\t458.70585699005755\n",
-      "\t50\t451.73884484855614\n",
-      "\n",
-      "Best k = 11\n",
-      "\n",
-      "426.440505 seconds (130.13 k allocations: 24.330 MiB, 0.00% gc time)\n"
-     ]
-    }
-   ],
-   "source": [
-    "Random.seed!(2020)\n",
-    "Yt = Matrix(Y')\n",
-    "Zt = Matrix(z')\n",
-    "@time mses = cv_iht(Yt, Transpose(xla), Zt, path=1:50);"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Conclusion:** Using $k = 12$ (which achieves minimum MSE) IHT finds 8/10 causal SNPs + 2 intercept terms. Beta estimates and cross-trait covariances are very precise. "
+    "**Conclusion:** Using $k = 11$ (which achieves minimum MSE) IHT finds 8/10 causal SNPs. Beta estimates and cross-trait covariances are very precise. "
    ]
   },
   {

--- a/test/multivariate.ipynb
+++ b/test/multivariate.ipynb
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 64,
    "metadata": {
     "collapsed": false
    },
@@ -57,6 +57,7 @@
    "source": [
     "n = 1000  # number of samples\n",
     "p = 10000 # number of SNPs\n",
+    "q = 100     # number of nongenetic covariates\n",
     "k = 10    # number of causal SNPs\n",
     "r = 2     # number of traits\n",
     "\n",
@@ -67,12 +68,13 @@
     "x = simulate_random_snparray(\"multivariate_$(r)traits.bed\", n, p)\n",
     "xla = SnpLinAlg{Float64}(x, model=ADDITIVE_MODEL, impute=false, center=true, scale=true) \n",
     "\n",
-    "# intercept is the only nongenetic covariate\n",
-    "z = ones(n, 1)\n",
-    "intercepts = randn(r)' # each trait have different intercept\n",
+    "# nongenetic covariates; intercept is the 1st column\n",
+    "z = randn(n, q)\n",
+    "z[:, 1] .= 1\n",
+    "c = randn(q, r)\n",
     "\n",
     "# simulate response y, true model b, and the correct non-0 positions of b\n",
-    "Y, true_Σ, true_b, correct_position = simulate_random_response(xla, k, r, Zu=z*intercepts, overlap=0);"
+    "Y, true_Σ, true_b, correct_position = simulate_random_response(xla, k, r, Zu=z*c, overlap=0);"
    ]
   },
   {
@@ -112,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 65,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -129,45 +131,159 @@
       "****                 Please cite our paper!                     ****\n",
       "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
       "\n",
-      "Initializing β to univariate regression values...\n"
+      "Initializing β to univariate regression values...\n",
+      "...completed in 0.1 seconds.\n",
+      "\n",
+      "Running sparse Multivariate Gaussian regression\n",
+      "Number of threads = 8\n",
+      "Link functin = IdentityLink()\n",
+      "Sparsity parameter (k) = 7\n",
+      "Prior weight scaling = off\n",
+      "Doubly sparse projection = off\n",
+      "Debias = off\n",
+      "Max IHT iterations = 200\n",
+      "Converging when tol < 0.0001 and iteration ≥ 5:\n",
+      "\n",
+      "Iteration 1: loglikelihood = -3239.8589067406742, backtracks = 0, tol = 0.4427892095041617\n",
+      "Iteration 2: loglikelihood = -2731.7061210910415, backtracks = 0, tol = 0.16754168717279966\n",
+      "Iteration 3: loglikelihood = -2550.5673137871936, backtracks = 0, tol = 0.08497521487704386\n",
+      "Iteration 4: loglikelihood = -2493.308225150741, backtracks = 0, tol = 0.05672386026896645\n",
+      "Iteration 5: loglikelihood = -2472.2063058232607, backtracks = 0, tol = 0.03025540957033393\n",
+      "Iteration 6: loglikelihood = -2427.9646561637373, backtracks = 1, tol = 0.01603943501824301\n",
+      "Iteration 7: loglikelihood = -2425.2137788718246, backtracks = 0, tol = 0.005758176063966135\n",
+      "Iteration 8: loglikelihood = -2423.7804023515546, backtracks = 0, tol = 0.005073242554428961\n",
+      "Iteration 9: loglikelihood = -2422.59497728477, backtracks = 1, tol = 0.003004555587295677\n",
+      "Iteration 10: loglikelihood = -2421.827693260786, backtracks = 0, tol = 0.003463378268843334\n",
+      "Iteration 11: loglikelihood = -2421.74729790867, backtracks = 0, tol = 0.0037864134860692692\n",
+      "Iteration 12: loglikelihood = -2420.977825207275, backtracks = 1, tol = 0.0028692956598098036\n",
+      "Iteration 13: loglikelihood = -2420.7254086390817, backtracks = 1, tol = 0.001390182799841965\n",
+      "Iteration 14: loglikelihood = -2420.5502915665074, backtracks = 0, tol = 0.001694452968771234\n",
+      "Iteration 15: loglikelihood = -2420.418736599853, backtracks = 1, tol = 0.0010161088778250242\n",
+      "Iteration 16: loglikelihood = -2420.3357831170388, backtracks = 0, tol = 0.0012043063670878484\n",
+      "Iteration 17: loglikelihood = -2420.26473811716, backtracks = 1, tol = 0.000756007310558418\n",
+      "Iteration 18: loglikelihood = -2420.2256698760343, backtracks = 0, tol = 0.0009018336806537366\n",
+      "Iteration 19: loglikelihood = -2420.186323807896, backtracks = 1, tol = 0.0005689384700532531\n",
+      "Iteration 20: loglikelihood = -2420.1681219967686, backtracks = 0, tol = 0.0006759777385461319\n",
+      "Iteration 21: loglikelihood = -2420.145878241366, backtracks = 1, tol = 0.0004317806394929476\n",
+      "Iteration 22: loglikelihood = -2420.1375671478054, backtracks = 0, tol = 0.0005073865472343943\n",
+      "Iteration 23: loglikelihood = -2420.1247720917813, backtracks = 1, tol = 0.00032989135676668137\n",
+      "Iteration 24: loglikelihood = -2420.1211100661953, backtracks = 0, tol = 0.0003815084170408862\n",
+      "Iteration 25: loglikelihood = -2420.1136407148406, backtracks = 1, tol = 0.00025343837132248506\n",
+      "Iteration 26: loglikelihood = -2420.1121282388976, backtracks = 0, tol = 0.00028744236541942676\n",
+      "Iteration 27: loglikelihood = -2420.1077126976606, backtracks = 1, tol = 0.00019560515660170164\n",
+      "Iteration 28: loglikelihood = -2420.1071655416054, backtracks = 0, tol = 0.00021705518117825666\n",
+      "Iteration 29: loglikelihood = -2420.104527196402, backtracks = 1, tol = 0.00015156139217107175\n",
+      "Iteration 30: loglikelihood = -2420.104391807603, backtracks = 0, tol = 0.0001642956680566473\n",
+      "Iteration 31: loglikelihood = -2420.102800978058, backtracks = 1, tol = 0.00011837828941596617\n",
+      "Iteration 32: loglikelihood = -2420.1022538427105, backtracks = 1, tol = 6.334305129653613e-5\n",
+      "  0.391157 seconds (64.54 k allocations: 166.231 MiB)\n"
      ]
     },
     {
-     "ename": "LoadError",
-     "evalue": "ArgumentError: invalid Array dimensions",
-     "output_type": "error",
-     "traceback": [
-      "ArgumentError: invalid Array dimensions",
-      "",
-      "Stacktrace:",
-      "  [1] Array",
-      "    @ ./boot.jl:450 [inlined]",
-      "  [2] MendelIHT.mIHTVariable(x::Transpose{Float64, SnpLinAlg{Float64}}, z::Matrix{Float64}, y::Matrix{Float64}, k::Int64, zkeep::BitVector)",
-      "    @ MendelIHT ~/.julia/dev/MendelIHT/src/data_structures.jl:199",
-      "  [3] #initialize#1",
-      "    @ ~/.julia/dev/MendelIHT/src/data_structures.jl:123 [inlined]",
-      "  [4] initialize",
-      "    @ ~/.julia/dev/MendelIHT/src/data_structures.jl:122 [inlined]",
-      "  [5] macro expansion",
-      "    @ ./timing.jl:287 [inlined]",
-      "  [6] fit_iht(y::Matrix{Float64}, x::Transpose{Float64, SnpLinAlg{Float64}}, z::Matrix{Float64}; k::Int64, J::Int64, d::ZeroMeanDiagNormal{Tuple{Base.OneTo{Int64}}}, l::IdentityLink, group::Vector{Int64}, weight::Vector{Float64}, zkeep::BitVector, est_r::Symbol, use_maf::Bool, debias::Bool, verbose::Bool, tol::Float64, max_iter::Int64, min_iter::Int64, max_step::Int64, io::IJulia.IJuliaStdio{Base.PipeEndpoint}, init_beta::Bool)",
-      "    @ MendelIHT ~/.julia/dev/MendelIHT/src/fit.jl:100",
-      "  [7] top-level scope",
-      "    @ ./timing.jl:210 [inlined]",
-      "  [8] top-level scope",
-      "    @ ./In[7]:0",
-      "  [9] eval",
-      "    @ ./boot.jl:360 [inlined]",
-      " [10] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)",
-      "    @ Base ./loading.jl:1094"
-     ]
+     "data": {
+      "text/plain": [
+       "\n",
+       "Compute time (sec):     0.3265831470489502\n",
+       "Final loglikelihood:    -2420.1022538427105\n",
+       "Iterations:             32\n",
+       "Trait 1's SNP PVE:      0.951081145560398\n",
+       "Trait 2's SNP PVE:      0.949788317267863\n",
+       "\n",
+       "Estimated trait covariance:\n",
+       "\u001b[1m2×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m trait1  \u001b[0m\u001b[1m trait2  \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Float64 \u001b[0m\u001b[90m Float64 \u001b[0m\n",
+       "─────┼──────────────────\n",
+       "   1 │ 5.79457  3.63796\n",
+       "   2 │ 3.63796  5.23835\n",
+       "\n",
+       "Trait 1: IHT estimated 4 nonzero SNP predictors\n",
+       "\u001b[1m4×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │      261    -0.623136\n",
+       "   2 │     2577     0.499328\n",
+       "   3 │     4767    -2.06477\n",
+       "   4 │     7654     1.0611\n",
+       "\n",
+       "Trait 1: IHT estimated 100 non-genetic predictors\n",
+       "\u001b[1m100×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │        1   1.98407\n",
+       "   2 │        2   0.204885\n",
+       "   3 │        3   0.778876\n",
+       "   4 │        4  -0.448998\n",
+       "   5 │        5   1.04494\n",
+       "   6 │        6   1.62274\n",
+       "   7 │        7  -1.47625\n",
+       "   8 │        8   0.550586\n",
+       "   9 │        9  -0.952757\n",
+       "  10 │       10  -1.03214\n",
+       "  11 │       11   0.665595\n",
+       "  ⋮  │    ⋮           ⋮\n",
+       "  91 │       91  -2.08925\n",
+       "  92 │       92   0.0335797\n",
+       "  93 │       93  -0.277294\n",
+       "  94 │       94   0.722251\n",
+       "  95 │       95   1.41426\n",
+       "  96 │       96  -1.48869\n",
+       "  97 │       97   0.130512\n",
+       "  98 │       98  -0.435264\n",
+       "  99 │       99   0.739788\n",
+       " 100 │      100   1.94191\n",
+       "\u001b[36m              79 rows omitted\u001b[0m\n",
+       "\n",
+       "Trait 2: IHT estimated 3 nonzero SNP predictors\n",
+       "\u001b[1m3×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │      540     0.522538\n",
+       "   2 │     4545    -1.22943\n",
+       "   3 │     8340     0.215909\n",
+       "\n",
+       "Trait 2: IHT estimated 100 non-genetic predictors\n",
+       "\u001b[1m100×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │        1   -1.21446\n",
+       "   2 │        2   -0.604014\n",
+       "   3 │        3    0.0585358\n",
+       "   4 │        4    0.0868805\n",
+       "   5 │        5   -1.5798\n",
+       "   6 │        6   -0.464744\n",
+       "   7 │        7   -1.52217\n",
+       "   8 │        8    0.281903\n",
+       "   9 │        9   -0.360509\n",
+       "  10 │       10   -0.481412\n",
+       "  11 │       11    0.111335\n",
+       "  ⋮  │    ⋮           ⋮\n",
+       "  91 │       91   -0.703698\n",
+       "  92 │       92    1.39321\n",
+       "  93 │       93    0.321649\n",
+       "  94 │       94   -0.665116\n",
+       "  95 │       95   -1.38466\n",
+       "  96 │       96    0.381183\n",
+       "  97 │       97    0.892373\n",
+       "  98 │       98    1.00259\n",
+       "  99 │       99    0.395847\n",
+       " 100 │      100   -0.421653\n",
+       "\u001b[36m              79 rows omitted\u001b[0m\n"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "Yt = Matrix(Y')\n",
     "Zt = Matrix(z')\n",
-    "ktrue = k + count(!iszero, intercepts)\n",
-    "@time result = fit_iht(Yt, Transpose(xla), Zt, k=0, init_beta=true)"
+    "@time result = fit_iht(Yt, Transpose(xla), Zt, k=7, init_beta=true)"
    ]
   },
   {
@@ -179,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 66,
    "metadata": {
     "collapsed": false
    },
@@ -187,17 +303,16 @@
     {
      "data": {
       "text/plain": [
-       "7×2 Matrix{Float64}:\n",
-       " -0.442363  -0.388067\n",
-       " -1.18046   -1.24972\n",
-       " -1.48331   -1.53835\n",
-       "  0.0       -0.0034339\n",
-       " -1.44301   -1.47163\n",
-       "  0.826897   0.758756\n",
-       " -0.804007  -0.847906"
+       "6×2 Matrix{Float64}:\n",
+       " -0.623136  -0.606503\n",
+       "  0.0       -0.0973917\n",
+       "  0.499328   0.584764\n",
+       " -2.06477   -2.13538\n",
+       "  1.0611     1.0853\n",
+       "  0.0       -0.242309"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -211,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 67,
    "metadata": {
     "collapsed": false
    },
@@ -219,13 +334,14 @@
     {
      "data": {
       "text/plain": [
-       "3×2 Matrix{Float64}:\n",
-       " -0.368701  -0.402269\n",
-       "  0.362197   0.296183\n",
-       "  0.0        0.125965"
+       "4×2 Matrix{Float64}:\n",
+       "  0.522538   0.592383\n",
+       "  0.0        0.363792\n",
+       " -1.22943   -1.2704\n",
+       "  0.0       -0.10426"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -239,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 68,
    "metadata": {
     "collapsed": false
    },
@@ -247,24 +363,48 @@
     {
      "data": {
       "text/plain": [
-       "2×2 Matrix{Float64}:\n",
-       " -0.119153  -0.172668\n",
-       "  0.862081   0.729135"
+       "200×2 Matrix{Float64}:\n",
+       "  1.98407     2.04426\n",
+       " -1.21446    -1.1548\n",
+       "  0.204885    0.411928\n",
+       " -0.604014   -0.471283\n",
+       "  0.778876    0.873763\n",
+       "  0.0585358   0.110743\n",
+       " -0.448998   -0.438718\n",
+       "  0.0868805   0.133405\n",
+       "  1.04494     1.14307\n",
+       " -1.5798     -1.50455\n",
+       "  1.62274     1.57622\n",
+       " -0.464744   -0.535578\n",
+       " -1.47625    -1.43399\n",
+       "  ⋮          \n",
+       "  1.41426     1.35095\n",
+       " -1.38466    -1.50165\n",
+       " -1.48869    -1.47478\n",
+       "  0.381183    0.446708\n",
+       "  0.130512    0.0020513\n",
+       "  0.892373    0.786244\n",
+       " -0.435264   -0.463497\n",
+       "  1.00259     0.966965\n",
+       "  0.739788    0.797359\n",
+       "  0.395847    0.310934\n",
+       "  1.94191     1.93984\n",
+       " -0.421653   -0.359157"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# non genetic covariates\n",
-    "[result.c intercepts']"
+    "[vec(result.c) vec(c')]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 69,
    "metadata": {
     "collapsed": false
    },
@@ -273,13 +413,13 @@
      "data": {
       "text/plain": [
        "4×2 Matrix{Float64}:\n",
-       "  4.71859     4.96944\n",
-       " -0.00358663  0.162057\n",
-       " -0.00358663  0.162057\n",
-       "  3.48276     3.74153"
+       " 5.79457  6.2004\n",
+       " 3.63796  4.0208\n",
+       " 3.63796  4.0208\n",
+       " 5.23835  5.67545"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -291,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 70,
    "metadata": {
     "collapsed": false
    },
@@ -299,18 +439,16 @@
     {
      "data": {
       "text/plain": [
-       "8-element Vector{Int64}:\n",
-       "  134\n",
-       "  442\n",
-       "  450\n",
-       " 1891\n",
-       " 2557\n",
-       " 3243\n",
-       " 1014\n",
-       " 5214"
+       "6-element Vector{Int64}:\n",
+       "  261\n",
+       " 2577\n",
+       " 4767\n",
+       " 7654\n",
+       "  540\n",
+       " 4545"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 45,
    "metadata": {
     "collapsed": false
    },
@@ -339,10 +477,10 @@
     {
      "data": {
       "text/plain": [
-       "1"
+       "8"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -353,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 46,
    "metadata": {
     "collapsed": false
    },
@@ -375,7 +513,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:14\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:03\u001b[39m\n"
      ]
     },
     {
@@ -386,31 +524,31 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t0\t3197.050276401111\n",
-      "\t1\t2785.5010133236\n",
-      "\t2\t2382.249270184595\n",
-      "\t3\t2097.8973543744823\n",
-      "\t4\t1975.867901548581\n",
-      "\t5\t1809.0805620608676\n",
-      "\t6\t1806.39486890902\n",
-      "\t7\t1776.8736737055538\n",
-      "\t8\t1756.6114229233608\n",
-      "\t9\t1758.7156108647926\n",
-      "\t10\t1758.6669076439284\n",
-      "\t11\t1753.7462845761318\n",
-      "\t12\t1778.5120850213254\n",
-      "\t13\t1765.1006203482223\n",
-      "\t14\t1781.2997877319665\n",
-      "\t15\t1783.3267519956285\n",
-      "\t16\t1810.6396785779898\n",
-      "\t17\t1795.7103455642555\n",
-      "\t18\t1829.1524569312926\n",
-      "\t19\t1806.8456952013657\n",
-      "\t20\t1833.0931393632602\n",
+      "\t0\t6469.203609848057\n",
+      "\t1\t2880.5248080533443\n",
+      "\t2\t2406.5255243578495\n",
+      "\t3\t2330.6608973836264\n",
+      "\t4\t2256.195685565707\n",
+      "\t5\t2193.4425949268725\n",
+      "\t6\t2144.320400354542\n",
+      "\t7\t2088.9197304282193\n",
+      "\t8\t2119.9961586628438\n",
+      "\t9\t2137.165024214338\n",
+      "\t10\t2156.800352576463\n",
+      "\t11\t2171.843435468765\n",
+      "\t12\t2202.541467918831\n",
+      "\t13\t2213.3907734937015\n",
+      "\t14\t2224.491848519913\n",
+      "\t15\t2253.5509913201836\n",
+      "\t16\t2256.1255203769924\n",
+      "\t17\t2227.789366736381\n",
+      "\t18\t2250.4551542593354\n",
+      "\t19\t2273.8809156024035\n",
+      "\t20\t2262.161085627236\n",
       "\n",
-      "Best k = 11\n",
+      "Best k = 7\n",
       "\n",
-      " 15.149703 seconds (8.15 M allocations: 744.348 MiB, 0.95% gc time)\n"
+      "  4.630256 seconds (7.98 M allocations: 684.319 MiB, 2.77% gc time)\n"
      ]
     }
    ],
@@ -423,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 47,
    "metadata": {
     "collapsed": false
    },
@@ -445,7 +583,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:26\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:08\u001b[39m\n"
      ]
     },
     {
@@ -456,31 +594,31 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t0\t3197.050276401111\n",
-      "\t1\t2785.4960809199397\n",
-      "\t2\t2382.246242980236\n",
-      "\t3\t2097.8954672657874\n",
-      "\t4\t1975.8677419771152\n",
-      "\t5\t1809.0806040738507\n",
-      "\t6\t1806.3766528763722\n",
-      "\t7\t1767.8668039124027\n",
-      "\t8\t1732.4558371446387\n",
-      "\t9\t1734.6916314487225\n",
-      "\t10\t1739.3711174539092\n",
-      "\t11\t1759.2677793938547\n",
-      "\t12\t1774.4168821915746\n",
-      "\t13\t1774.578320164292\n",
-      "\t14\t1774.7289649894753\n",
-      "\t15\t1792.6312493255998\n",
-      "\t16\t1833.2730465887287\n",
-      "\t17\t1813.65098766714\n",
-      "\t18\t1855.3609954310311\n",
-      "\t19\t1834.9878430150566\n",
-      "\t20\t1852.100577093223\n",
+      "\t0\t4834.866700030927\n",
+      "\t1\t2880.521175990194\n",
+      "\t2\t2406.5280839532666\n",
+      "\t3\t2330.6616574229197\n",
+      "\t4\t2256.197058928352\n",
+      "\t5\t2193.453496654248\n",
+      "\t6\t2144.325277416228\n",
+      "\t7\t2088.9213366500476\n",
+      "\t8\t2117.8833693852644\n",
+      "\t9\t2128.4472613034945\n",
+      "\t10\t2165.517781225008\n",
+      "\t11\t2175.233272262217\n",
+      "\t12\t2182.878605121384\n",
+      "\t13\t2204.344947281428\n",
+      "\t14\t2213.0563673176975\n",
+      "\t15\t2230.0505108855705\n",
+      "\t16\t2236.201538232794\n",
+      "\t17\t2250.1174700466236\n",
+      "\t18\t2263.987299591203\n",
+      "\t19\t2301.466032165297\n",
+      "\t20\t2302.024784259434\n",
       "\n",
-      "Best k = 8\n",
+      "Best k = 7\n",
       "\n",
-      " 26.684120 seconds (6.38 M allocations: 13.198 GiB, 4.24% gc time)\n"
+      "  8.495308 seconds (6.37 M allocations: 13.192 GiB, 29.06% gc time)\n"
      ]
     }
    ],
@@ -489,13 +627,6 @@
     "Yt = Matrix(Y')\n",
     "Zt = Matrix(z')\n",
     "@time mses = cv_iht(Yt, Transpose(xla), Zt, path=0:20, init_beta=true);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Conclusion:** Using $k = 11$ (which achieves minimum MSE) IHT finds 8/10 causal SNPs. Beta estimates and cross-trait covariances are very precise. "
    ]
   },
   {

--- a/test/multivariate_test.jl
+++ b/test/multivariate_test.jl
@@ -19,7 +19,7 @@ function make_mIHTvar(r) # r = number of traits
     # everything is transposed for multivariate analysis!
     Yt = Matrix(Y')
     Zt = Matrix(z')
-    v = MendelIHT.mIHTVariable(Transpose(xla), Zt, Yt, k)
+    v = MendelIHT.mIHTVariable(Transpose(xla), Zt, Yt, k, trues(1))
 
     return v, Transpose(xla), Yt, Zt, k
 end
@@ -53,6 +53,7 @@ end
 
     # r = 2 traits
     v, xla, Yt, Zt, k = make_mIHTvar(2)
+    zkeep = trues(1)
     MendelIHT.init_iht_indices!(v, false, trues(size(xla, 2)))
     @btime MendelIHT.score!($v)           # 9.304 ms (45 allocations: 2.33 KiB)
     @btime MendelIHT.loglikelihood($v)    # 3.377 μs (2 allocations: 208 bytes)
@@ -61,8 +62,8 @@ end
     @btime MendelIHT._choose!($v)         # 16.698 μs (3 allocations: 208 bytes)
     @btime MendelIHT.solve_Σ!($v)         # 2.889 μs (2 allocations: 48 bytes)
     # @btime MendelIHT.iht_stepsize(v) # cannot be done because BenchmarkTools require multiple evaluations of the same function call, which makes Γ not pd
-    @btime MendelIHT.vectorize!($(v.full_b), $(v.B), $(v.C)) # 10.299 μs (0 allocations: 0 bytes)
-    @btime MendelIHT.unvectorize!($(v.full_b), $(v.B), $(v.C)) # 10.548 μs (0 allocations: 0 bytes)
+    @btime MendelIHT.vectorize!($(v.full_b), $(v.B), $(v.C), $zkeep) # 10.299 μs (0 allocations: 0 bytes)
+    @btime MendelIHT.unvectorize!($(v.full_b), $(v.B), $(v.C), $zkeep) # 10.548 μs (0 allocations: 0 bytes)
     @btime MendelIHT.update_support!($(v.idx), $(v.B)) # 23.204 μs (0 allocations: 0 bytes)
 
     # r = 10 traits
@@ -75,8 +76,8 @@ end
     @btime MendelIHT._choose!($v)         # 68.161 μs (5 allocations: 432 bytes)
     @btime MendelIHT.solve_Σ!($v)         # 12.623 μs (2 allocations: 48 bytes)
     # @btime MendelIHT.iht_stepsize(v) # cannot be done because BenchmarkTools require multiple evaluations of the same function call, which makes Γ not pd
-    @btime MendelIHT.vectorize!($(v.full_b), $(v.B), $(v.C)) # 23.712 μs (0 allocations: 0 bytes)
-    @btime MendelIHT.unvectorize!($(v.full_b), $(v.B), $(v.C)) # 23.761 μs (0 allocations: 0 bytes)
+    @btime MendelIHT.vectorize!($(v.full_b), $(v.B), $(v.C), $zkeep) # 23.712 μs (0 allocations: 0 bytes)
+    @btime MendelIHT.unvectorize!($(v.full_b), $(v.B), $(v.C), $zkeep) # 23.761 μs (0 allocations: 0 bytes)
     @btime MendelIHT.update_support!($(v.idx), $(v.B)) # 50.047 μs (0 allocations: 0 bytes)
 end
 

--- a/test/univariate.ipynb
+++ b/test/univariate.ipynb
@@ -50,6 +50,7 @@
    "source": [
     "n = 1000  # number of samples\n",
     "p = 10000 # number of SNPs\n",
+    "q = 5     # number of non-genetic covariates\n",
     "k = 10    # number of causal SNPs per trait\n",
     "d = Normal\n",
     "l = canonicallink(d())\n",
@@ -61,12 +62,13 @@
     "x = simulate_random_snparray(undef, n, p)\n",
     "xla = SnpLinAlg{Float64}(x, model=ADDITIVE_MODEL, center=true, scale=true) \n",
     "\n",
-    "# intercept is the only nongenetic covariate\n",
-    "z = ones(n)\n",
-    "intercept = 1.0\n",
+    "# nongenetic covarites, 1st column is intercept\n",
+    "z = randn(n, q)\n",
+    "z[:, 1] .= 1\n",
+    "c = randn(q)\n",
     "\n",
     "# simulate response y, true model b, and the correct non-0 positions of b\n",
-    "y, true_b, correct_position = simulate_random_response(xla, k, d, l, Zu=z*intercept);"
+    "y, true_b, correct_position = simulate_random_response(xla, k, d, l, Zu=z*c);"
    ]
   },
   {
@@ -78,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -99,7 +101,7 @@
       "...completed in 0.1 seconds.\n",
       "\n",
       "Running sparse linear regression\n",
-      "Number of threads = 1\n",
+      "Number of threads = 8\n",
       "Link functin = IdentityLink()\n",
       "Sparsity parameter (k) = 10\n",
       "Prior weight scaling = off\n",
@@ -108,26 +110,26 @@
       "Max IHT iterations = 200\n",
       "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -2486.6803542089983, backtracks = 0, tol = 0.5168146007666207\n",
-      "Iteration 2: loglikelihood = -1576.084706218103, backtracks = 0, tol = 0.3348001846027596\n",
-      "Iteration 3: loglikelihood = -1482.661472264235, backtracks = 0, tol = 0.12659393834337299\n",
-      "Iteration 4: loglikelihood = -1474.102834009593, backtracks = 0, tol = 0.05395777111917327\n",
-      "Iteration 5: loglikelihood = -1472.6103945500831, backtracks = 0, tol = 0.05424817330897465\n",
-      "Iteration 6: loglikelihood = -1472.3921697946553, backtracks = 0, tol = 0.004846687028422366\n",
-      "Iteration 7: loglikelihood = -1472.3905862479874, backtracks = 0, tol = 0.00043152364883453044\n",
-      "Iteration 8: loglikelihood = -1472.3905616484403, backtracks = 0, tol = 6.162053430185662e-5\n",
-      "  0.135606 seconds (212.21 k allocations: 82.139 MiB)\n"
+      "Iteration 1: loglikelihood = -3002.723211083534, backtracks = 0, tol = 0.6926932469992776\n",
+      "Iteration 2: loglikelihood = -1805.3237453585161, backtracks = 0, tol = 0.34637684087692966\n",
+      "Iteration 3: loglikelihood = -1460.2586248070177, backtracks = 0, tol = 0.14587250928135054\n",
+      "Iteration 4: loglikelihood = -1423.3099178063696, backtracks = 0, tol = 0.051734443856394426\n",
+      "Iteration 5: loglikelihood = -1422.4175728900736, backtracks = 0, tol = 0.006748431563871328\n",
+      "Iteration 6: loglikelihood = -1422.404406446152, backtracks = 0, tol = 0.000651137890535953\n",
+      "Iteration 7: loglikelihood = -1422.4040859621814, backtracks = 0, tol = 0.00012325020747103993\n",
+      "Iteration 8: loglikelihood = -1422.4040762615862, backtracks = 0, tol = 2.4236459572952715e-5\n",
+      "  0.780499 seconds (1.64 M allocations: 160.835 MiB, 4.27% gc time, 59.58% compilation time)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "\n",
-       "IHT estimated 10 nonzero SNP predictors and 1 non-genetic predictors.\n",
+       "IHT estimated 10 nonzero SNP predictors and 5 non-genetic predictors.\n",
        "\n",
-       "Compute time (sec):     0.03817605972290039\n",
-       "Final loglikelihood:    -1472.3905616484403\n",
-       "SNP PVE:                0.8426997403655612\n",
+       "Compute time (sec):     0.06963992118835449\n",
+       "Final loglikelihood:    -1422.4040762615862\n",
+       "SNP PVE:                0.7545490924593975\n",
        "Iterations:             8\n",
        "\n",
        "Selected genetic predictors:\n",
@@ -135,26 +137,30 @@
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │      782    -0.437816\n",
-       "   2 │      901     0.747927\n",
-       "   3 │     1204     0.691428\n",
-       "   4 │     1306    -1.425\n",
-       "   5 │     1655    -0.194702\n",
-       "   6 │     3160    -0.86171\n",
-       "   7 │     3936    -0.147419\n",
-       "   8 │     4201     0.338541\n",
-       "   9 │     4402    -0.126501\n",
-       "  10 │     6879    -1.21893\n",
+       "   1 │     1487    -0.678565\n",
+       "   2 │     1734    -0.169403\n",
+       "   3 │     2097    -2.13101\n",
+       "   4 │     2266    -0.235182\n",
+       "   5 │     2551     0.16789\n",
+       "   6 │     4775     2.29512\n",
+       "   7 │     4791     0.763704\n",
+       "   8 │     4955    -0.417309\n",
+       "   9 │     7933    -1.72017\n",
+       "  10 │     8710    -0.565201\n",
        "\n",
        "Selected nongenetic predictors:\n",
-       "\u001b[1m1×2 DataFrame\u001b[0m\n",
+       "\u001b[1m5×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │        1      1.02016"
+       "   1 │        1    0.125532\n",
+       "   2 │        2    1.15239\n",
+       "   3 │        3   -0.58176\n",
+       "   4 │        4    1.42219\n",
+       "   5 │        5   -0.0582245"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -172,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -181,56 +187,25 @@
      "data": {
       "text/plain": [
        "10×2 Matrix{Float64}:\n",
-       " -0.402269   -0.437816\n",
-       "  0.758756    0.747927\n",
-       "  0.729135    0.691428\n",
-       " -1.47163    -1.425\n",
-       " -0.172668   -0.194702\n",
-       " -0.847906   -0.86171\n",
-       "  0.296183    0.338541\n",
-       " -0.0034339   0.0\n",
-       "  0.125965    0.0\n",
-       " -1.24972    -1.21893"
+       " -0.674202  -0.678565\n",
+       " -0.212237  -0.169403\n",
+       " -2.16656   -2.13101\n",
+       " -0.203392  -0.235182\n",
+       "  0.165819   0.16789\n",
+       "  2.30263    2.29512\n",
+       "  0.687439   0.763704\n",
+       " -0.405677  -0.417309\n",
+       " -1.66149   -1.72017\n",
+       " -0.546303  -0.565201"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "[true_b[correct_position] result.beta[correct_position]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1×2 Matrix{Float64}:\n",
-       " 1.02016  1.0"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# non genetic covariates\n",
-    "[result.c intercept]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Test Cross validation"
    ]
   },
   {
@@ -243,10 +218,45 @@
     {
      "data": {
       "text/plain": [
-       "1"
+       "5×2 Matrix{Float64}:\n",
+       "  0.125532    0.0284927\n",
+       "  1.15239     1.13825\n",
+       " -0.58176    -0.566457\n",
+       "  1.42219     1.35203\n",
+       " -0.0582245  -0.0531031"
       ]
      },
      "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# non genetic covariates\n",
+    "[result.c c]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test Cross validation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -257,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -279,7 +289,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:13\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:06\u001b[39m\n"
      ]
     },
     {
@@ -290,37 +300,264 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t0\t1097.9822679456634\n",
-      "\t1\t639.948435659851\n",
-      "\t2\t639.948435659851\n",
-      "\t3\t491.31091160253413\n",
-      "\t4\t414.7982590934014\n",
-      "\t5\t307.63048180391786\n",
-      "\t6\t266.95374125278414\n",
-      "\t7\t242.0572267640577\n",
-      "\t8\t236.23211459381542\n",
-      "\t9\t243.58873069893227\n",
-      "\t10\t245.6937243742038\n",
-      "\t11\t246.44391892259432\n",
-      "\t12\t254.05026743790478\n",
-      "\t13\t256.2080803045909\n",
-      "\t14\t260.3857536819678\n",
-      "\t15\t260.5867303978344\n",
-      "\t16\t270.1163325764251\n",
-      "\t17\t275.10575084293146\n",
-      "\t18\t276.73604590979255\n",
-      "\t19\t280.43703442081045\n",
-      "\t20\t272.60846960582063\n",
+      "\t0\t3046.1068850324336\n",
+      "\t1\t2014.9680141393687\n",
+      "\t2\t1153.520612853073\n",
+      "\t3\t527.4303875427266\n",
+      "\t4\t421.56539803705937\n",
+      "\t5\t334.607065931551\n",
+      "\t6\t267.76045903864633\n",
+      "\t7\t231.18007562734212\n",
+      "\t8\t218.7115381296477\n",
+      "\t9\t219.93024184511523\n",
+      "\t10\t212.56326397610883\n",
+      "\t11\t216.42591815912317\n",
+      "\t12\t218.52008060795322\n",
+      "\t13\t225.76746161959892\n",
+      "\t14\t231.14431195338898\n",
+      "\t15\t234.36915696941708\n",
+      "\t16\t233.17497749362144\n",
+      "\t17\t240.68670944533042\n",
+      "\t18\t248.3512559330554\n",
+      "\t19\t245.9563361500128\n",
+      "\t20\t246.6022429280416\n",
       "\n",
-      "Best k = 8\n",
+      "Best k = 10\n",
       "\n",
-      " 14.263994 seconds (30.21 M allocations: 7.031 GiB, 5.04% gc time)\n"
+      "  7.188606 seconds (35.71 M allocations: 7.338 GiB, 24.04% gc time)\n"
      ]
     }
    ],
    "source": [
     "Random.seed!(2020)\n",
     "@time mses = cv_iht(y, xla, z, path=0:20, init_beta=true);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Logistic (binary) traits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "n = 1000  # number of samples\n",
+    "p = 10000 # number of SNPs\n",
+    "q = 3     # number of non-genetic covariates\n",
+    "k = 10    # number of causal SNPs per trait\n",
+    "d = Bernoulli\n",
+    "l = canonicallink(d())\n",
+    "\n",
+    "# set random seed for reproducibility\n",
+    "Random.seed!(2021)\n",
+    "\n",
+    "# simulate `.bed` file with no missing data\n",
+    "x = simulate_random_snparray(undef, n, p)\n",
+    "xla = SnpLinAlg{Float64}(x, model=ADDITIVE_MODEL, center=true, scale=true) \n",
+    "\n",
+    "# nongenetic covarites, 1st column is intercept\n",
+    "z = randn(n, q)\n",
+    "z[:, 1] .= 1\n",
+    "c = randn(q)\n",
+    "\n",
+    "# simulate response y, true model b, and the correct non-0 positions of b\n",
+    "y, true_b, correct_position = simulate_random_response(xla, k, d, l, Zu=z*c);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "****                   MendelIHT Version 1.4.1                  ****\n",
+      "****     Benjamin Chu, Kevin Keys, Chris German, Hua Zhou       ****\n",
+      "****   Jin Zhou, Eric Sobel, Janet Sinsheimer, Kenneth Lange    ****\n",
+      "****                                                            ****\n",
+      "****                 Please cite our paper!                     ****\n",
+      "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
+      "\n",
+      "Running sparse logistic regression\n",
+      "Number of threads = 8\n",
+      "Link functin = LogitLink()\n",
+      "Sparsity parameter (k) = 10\n",
+      "Prior weight scaling = off\n",
+      "Doubly sparse projection = off\n",
+      "Debias = off\n",
+      "Max IHT iterations = 1000\n",
+      "Converging when tol < 0.0001 and iteration ≥ 5:\n",
+      "\n",
+      "Iteration 1: loglikelihood = -395.77014413725806, backtracks = 0, tol = 0.5303310300461843\n",
+      "Iteration 2: loglikelihood = -346.3417924804989, backtracks = 0, tol = 0.29597732231115287\n",
+      "Iteration 3: loglikelihood = -326.09265897099965, backtracks = 0, tol = 0.26341642913501495\n",
+      "Iteration 4: loglikelihood = -320.75740042076006, backtracks = 0, tol = 0.20018197099630855\n",
+      "Iteration 5: loglikelihood = -316.7539463187656, backtracks = 0, tol = 0.19029896307061697\n",
+      "Iteration 6: loglikelihood = -315.40437843521266, backtracks = 1, tol = 0.022327441608785404\n",
+      "Iteration 7: loglikelihood = -314.7567800816027, backtracks = 2, tol = 0.013175720795655016\n",
+      "Iteration 8: loglikelihood = -314.40067185287734, backtracks = 3, tol = 0.007853420243270988\n",
+      "Iteration 9: loglikelihood = -314.10611274239784, backtracks = 3, tol = 0.007358484783868825\n",
+      "Iteration 10: loglikelihood = -313.8699078756278, backtracks = 3, tol = 0.006771534573371636\n",
+      "Iteration 11: loglikelihood = -313.6827957680445, backtracks = 3, tol = 0.006130778191762448\n",
+      "Iteration 12: loglikelihood = -313.53545791921914, backtracks = 3, tol = 0.005498228488007286\n",
+      "Iteration 13: loglikelihood = -313.4198832289537, backtracks = 3, tol = 0.004909795033684663\n",
+      "Iteration 14: loglikelihood = -313.3294901368055, backtracks = 3, tol = 0.004381121740939437\n",
+      "Iteration 15: loglikelihood = -313.2589665785989, backtracks = 3, tol = 0.003895489922605362\n",
+      "Iteration 16: loglikelihood = -313.2040638910332, backtracks = 3, tol = 0.003454716963952091\n",
+      "Iteration 17: loglikelihood = -313.16140408776647, backtracks = 3, tol = 0.0030577558827093866\n",
+      "Iteration 18: loglikelihood = -313.1283137884559, backtracks = 3, tol = 0.002702149181323474\n",
+      "Iteration 19: loglikelihood = -313.10268547323363, backtracks = 3, tol = 0.002384810925477528\n",
+      "Iteration 20: loglikelihood = -313.0828633647061, backtracks = 3, tol = 0.0021024485492860054\n",
+      "Iteration 21: loglikelihood = -313.06755052051057, backtracks = 3, tol = 0.0018517883910968058\n",
+      "Iteration 22: loglikelihood = -313.05573378975816, backtracks = 3, tol = 0.0016296937987857847\n",
+      "Iteration 23: loglikelihood = -313.0466235990548, backtracks = 3, tol = 0.001433224111563226\n",
+      "Iteration 24: loglikelihood = -313.0396059141759, backtracks = 3, tol = 0.001259660768183166\n",
+      "Iteration 25: loglikelihood = -313.0342041075455, backtracks = 3, tol = 0.0011065148729601868\n",
+      "Iteration 26: loglikelihood = -313.03004882232716, backtracks = 3, tol = 0.0009715241612243385\n",
+      "Iteration 27: loglikelihood = -313.0268542485522, backtracks = 3, tol = 0.0008526438831652432\n",
+      "Iteration 28: loglikelihood = -313.02439951067737, backtracks = 3, tol = 0.0007480342716080388\n",
+      "Iteration 29: loglikelihood = -313.0225141090993, backtracks = 3, tol = 0.0006560462294485137\n",
+      "Iteration 30: loglikelihood = -313.0210665626331, backtracks = 3, tol = 0.0005752062763843058\n",
+      "Iteration 31: loglikelihood = -313.0199555686808, backtracks = 3, tol = 0.0005042014312168337\n",
+      "Iteration 32: loglikelihood = -313.01910313695004, backtracks = 3, tol = 0.000441864472191807\n",
+      "Iteration 33: loglikelihood = -313.0184492656348, backtracks = 3, tol = 0.0003871598602025497\n",
+      "Iteration 34: loglikelihood = -313.01794782001235, backtracks = 3, tol = 0.0003391704997852685\n",
+      "Iteration 35: loglikelihood = -313.0175633462547, backtracks = 3, tol = 0.00029708543484781953\n",
+      "Iteration 36: loglikelihood = -313.0172686112086, backtracks = 3, tol = 0.00026018852050755254\n",
+      "Iteration 37: loglikelihood = -313.01704270474164, backtracks = 3, tol = 0.0002278480731891781\n",
+      "Iteration 38: loglikelihood = -313.01686957735086, backtracks = 3, tol = 0.00019950747401636316\n",
+      "Iteration 39: loglikelihood = -313.01673691413356, backtracks = 3, tol = 0.00017467668247120695\n",
+      "Iteration 40: loglikelihood = -313.01663526834585, backtracks = 3, tol = 0.00015292460597413998\n",
+      "Iteration 41: loglikelihood = -313.01655739514143, backtracks = 3, tol = 0.0001338722646990945\n",
+      "Iteration 42: loglikelihood = -313.0164977395014, backtracks = 3, tol = 0.00011718668821769732\n",
+      "Iteration 43: loglikelihood = -313.0164520428757, backtracks = 3, tol = 0.00010257548043171457\n",
+      "Iteration 44: loglikelihood = -313.01641704112535, backtracks = 3, tol = 8.978199090393757e-5\n",
+      "  0.275917 seconds (2.03 M allocations: 44.658 MiB, 7.66% gc time)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "IHT estimated 10 nonzero SNP predictors and 3 non-genetic predictors.\n",
+       "\n",
+       "Compute time (sec):     0.26929783821105957\n",
+       "Final loglikelihood:    -313.01641704112535\n",
+       "SNP PVE:                0.5791181046176805\n",
+       "Iterations:             44\n",
+       "\n",
+       "Selected genetic predictors:\n",
+       "\u001b[1m10×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │      181    -0.889481\n",
+       "   2 │     1007     1.00471\n",
+       "   3 │     2417     0.891502\n",
+       "   4 │     3242    -0.641796\n",
+       "   5 │     3264    -0.925003\n",
+       "   6 │     3488    -1.61155\n",
+       "   7 │     6083    -0.84155\n",
+       "   8 │     6934     1.63939\n",
+       "   9 │     7118    -1.06178\n",
+       "  10 │     8119    -0.406123\n",
+       "\n",
+       "Selected nongenetic predictors:\n",
+       "\u001b[1m3×2 DataFrame\u001b[0m\n",
+       "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
+       "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
+       "─────┼───────────────────────\n",
+       "   1 │        1    -0.521723\n",
+       "   2 │        2     0.453126\n",
+       "   3 │        3    -1.63495"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@time result = fit_iht(y, xla, z, k=10, d=d(), l=l, init_beta=false, max_iter=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## chech answers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10×2 Matrix{Float64}:\n",
+       " -0.852107  -0.889481\n",
+       " -0.388558   0.0\n",
+       "  0.989745   1.00471\n",
+       "  0.647143   0.891502\n",
+       " -0.616519  -0.641796\n",
+       " -0.992854  -0.925003\n",
+       " -1.59093   -1.61155\n",
+       " -0.725757  -0.84155\n",
+       "  1.5154     1.63939\n",
+       " -1.15028   -1.06178"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[true_b[correct_position] result.beta[correct_position]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3×2 Matrix{Float64}:\n",
+       " -0.521723  -0.550508\n",
+       "  0.453126   0.38738\n",
+       " -1.63495   -1.61836"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# non genetic covariates\n",
+    "[result.c c]"
    ]
   },
   {

--- a/test/univariate.ipynb
+++ b/test/univariate.ipynb
@@ -12,30 +12,25 @@
      "output_type": "stream",
      "text": [
       "┌ Info: Precompiling MendelIHT [921c7187-1484-5754-b919-5d3ed9ac03c4]\n",
-      "└ @ Base loading.jl:1278\n"
+      "└ @ Base loading.jl:1317\n"
      ]
     }
    ],
    "source": [
-    "using Distributed\n",
-    "addprocs(4)\n",
-    "\n",
-    "@everywhere begin\n",
-    "    using Revise\n",
-    "    using MendelIHT\n",
-    "    using SnpArrays\n",
-    "    using Random\n",
-    "    using GLM\n",
-    "    using DelimitedFiles\n",
-    "    using Test\n",
-    "    using Distributions\n",
-    "    using LinearAlgebra\n",
-    "    using CSV\n",
-    "    using DataFrames\n",
-    "    using StatsBase\n",
-    "    BLAS.set_num_threads(1) # remember to set BLAS threads to 1 !!!\n",
-    "#     using TraitSimulation, OrdinalMultinomialModels, VarianceComponentModels\n",
-    "end"
+    "using Revise\n",
+    "using MendelIHT\n",
+    "using SnpArrays\n",
+    "using Random\n",
+    "using GLM\n",
+    "using DelimitedFiles\n",
+    "using Test\n",
+    "using Distributions\n",
+    "using LinearAlgebra\n",
+    "using CSV\n",
+    "using DataFrames\n",
+    "using StatsBase\n",
+    "BLAS.set_num_threads(1) # remember to set BLAS threads to 1 !!!\n",
+    "#     using TraitSimulation, OrdinalMultinomialModels, VarianceComponentModels"
    ]
   },
   {
@@ -47,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -83,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -93,33 +88,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "****                   MendelIHT Version 1.4.0                  ****\n",
+      "****                   MendelIHT Version 1.4.1                  ****\n",
       "****     Benjamin Chu, Kevin Keys, Chris German, Hua Zhou       ****\n",
       "****   Jin Zhou, Eric Sobel, Janet Sinsheimer, Kenneth Lange    ****\n",
       "****                                                            ****\n",
       "****                 Please cite our paper!                     ****\n",
       "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
       "\n",
+      "Initializing β to univariate regression values...\n",
+      "...completed in 0.1 seconds.\n",
+      "\n",
       "Running sparse linear regression\n",
+      "Number of threads = 1\n",
       "Link functin = IdentityLink()\n",
-      "Sparsity parameter (k) = 11\n",
+      "Sparsity parameter (k) = 10\n",
       "Prior weight scaling = off\n",
       "Doubly sparse projection = off\n",
       "Debias = off\n",
       "Max IHT iterations = 200\n",
-      "Converging when tol < 0.0001:\n",
+      "Converging when tol < 0.0001 and iteration ≥ 5:\n",
       "\n",
-      "Iteration 1: loglikelihood = -1577.1707947596879, backtracks = 0, tol = 0.6098646752831619\n",
-      "Iteration 2: loglikelihood = -1484.856813620618, backtracks = 0, tol = 0.1269955771967064\n",
-      "Iteration 3: loglikelihood = -1472.9529635904933, backtracks = 0, tol = 0.05823372413927715\n",
-      "Iteration 4: loglikelihood = -1472.5366421393844, backtracks = 1, tol = 0.004508958581388824\n",
-      "Iteration 5: loglikelihood = -1472.4280269450728, backtracks = 1, tol = 0.0023477261313534165\n",
-      "Iteration 6: loglikelihood = -1472.4000760087492, backtracks = 1, tol = 0.001186942797520523\n",
-      "Iteration 7: loglikelihood = -1472.3929618828483, backtracks = 1, tol = 0.00058854690910047\n",
-      "Iteration 8: loglikelihood = -1472.391164492576, backtracks = 1, tol = 0.0003036712554525334\n",
-      "Iteration 9: loglikelihood = -1472.3907123942718, backtracks = 1, tol = 0.0001547292323445728\n",
-      "Iteration 10: loglikelihood = -1472.3905989669602, backtracks = 1, tol = 7.825885379714214e-5\n",
-      "  0.128489 seconds (271.07 k allocations: 6.340 MiB)\n"
+      "Iteration 1: loglikelihood = -2486.6803542089983, backtracks = 0, tol = 0.5168146007666207\n",
+      "Iteration 2: loglikelihood = -1576.084706218103, backtracks = 0, tol = 0.3348001846027596\n",
+      "Iteration 3: loglikelihood = -1482.661472264235, backtracks = 0, tol = 0.12659393834337299\n",
+      "Iteration 4: loglikelihood = -1474.102834009593, backtracks = 0, tol = 0.05395777111917327\n",
+      "Iteration 5: loglikelihood = -1472.6103945500831, backtracks = 0, tol = 0.05424817330897465\n",
+      "Iteration 6: loglikelihood = -1472.3921697946553, backtracks = 0, tol = 0.004846687028422366\n",
+      "Iteration 7: loglikelihood = -1472.3905862479874, backtracks = 0, tol = 0.00043152364883453044\n",
+      "Iteration 8: loglikelihood = -1472.3905616484403, backtracks = 0, tol = 6.162053430185662e-5\n",
+      "  0.135606 seconds (212.21 k allocations: 82.139 MiB)\n"
      ]
     },
     {
@@ -128,26 +125,26 @@
        "\n",
        "IHT estimated 10 nonzero SNP predictors and 1 non-genetic predictors.\n",
        "\n",
-       "Compute time (sec):     0.1159050464630127\n",
-       "Final loglikelihood:    -1472.3907123942718\n",
-       "SNP PVE:                0.8426548660312022\n",
-       "Iterations:             10\n",
+       "Compute time (sec):     0.03817605972290039\n",
+       "Final loglikelihood:    -1472.3905616484403\n",
+       "SNP PVE:                0.8426997403655612\n",
+       "Iterations:             8\n",
        "\n",
        "Selected genetic predictors:\n",
        "\u001b[1m10×2 DataFrame\u001b[0m\n",
        "\u001b[1m Row \u001b[0m│\u001b[1m Position \u001b[0m\u001b[1m Estimated_β \u001b[0m\n",
        "\u001b[1m     \u001b[0m│\u001b[90m Int64    \u001b[0m\u001b[90m Float64     \u001b[0m\n",
        "─────┼───────────────────────\n",
-       "   1 │      782    -0.437833\n",
-       "   2 │      901     0.74798\n",
-       "   3 │     1204     0.691217\n",
-       "   4 │     1306    -1.42511\n",
-       "   5 │     1655    -0.194394\n",
-       "   6 │     3160    -0.861465\n",
-       "   7 │     3936    -0.147045\n",
-       "   8 │     4201     0.338675\n",
-       "   9 │     4402    -0.126433\n",
-       "  10 │     6879    -1.21895\n",
+       "   1 │      782    -0.437816\n",
+       "   2 │      901     0.747927\n",
+       "   3 │     1204     0.691428\n",
+       "   4 │     1306    -1.425\n",
+       "   5 │     1655    -0.194702\n",
+       "   6 │     3160    -0.86171\n",
+       "   7 │     3936    -0.147419\n",
+       "   8 │     4201     0.338541\n",
+       "   9 │     4402    -0.126501\n",
+       "  10 │     6879    -1.21893\n",
        "\n",
        "Selected nongenetic predictors:\n",
        "\u001b[1m1×2 DataFrame\u001b[0m\n",
@@ -157,13 +154,13 @@
        "   1 │        1      1.02016"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "@time result = fit_iht(y, xla, z, k=11)"
+    "@time result = fit_iht(y, xla, z, k=10, init_beta=true)"
    ]
   },
   {
@@ -171,6 +168,38 @@
    "metadata": {},
    "source": [
     "## Check answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10×2 Matrix{Float64}:\n",
+       " -0.402269   -0.437816\n",
+       "  0.758756    0.747927\n",
+       "  0.729135    0.691428\n",
+       " -1.47163    -1.425\n",
+       " -0.172668   -0.194702\n",
+       " -0.847906   -0.86171\n",
+       "  0.296183    0.338541\n",
+       " -0.0034339   0.0\n",
+       "  0.125965    0.0\n",
+       " -1.24972    -1.21893"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[true_b[correct_position] result.beta[correct_position]]"
    ]
   },
   {
@@ -183,43 +212,11 @@
     {
      "data": {
       "text/plain": [
-       "10×2 Array{Float64,2}:\n",
-       " -0.402269   -0.437833\n",
-       "  0.758756    0.74798\n",
-       "  0.729135    0.691217\n",
-       " -1.47163    -1.42511\n",
-       " -0.172668   -0.194394\n",
-       " -0.847906   -0.861465\n",
-       "  0.296183    0.338675\n",
-       " -0.0034339   0.0\n",
-       "  0.125965    0.0\n",
-       " -1.24972    -1.21895"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "[true_b[correct_position] result.beta[correct_position]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1×2 Array{Float64,2}:\n",
+       "1×2 Matrix{Float64}:\n",
        " 1.02016  1.0"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,16 +235,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Threads.nthreads()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "****                   MendelIHT Version 1.4.1                  ****\n",
+      "****     Benjamin Chu, Kevin Keys, Chris German, Hua Zhou       ****\n",
+      "****   Jin Zhou, Eric Sobel, Janet Sinsheimer, Kenneth Lange    ****\n",
+      "****                                                            ****\n",
+      "****                 Please cite our paper!                     ****\n",
+      "****         https://doi.org/10.1093/gigascience/giaa044        ****\n",
+      "\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:05\u001b[39m\n"
+      "\u001b[32mCross validating...100%|████████████████████████████████| Time: 0:00:13\u001b[39m\n"
      ]
     },
     {
@@ -258,36 +290,37 @@
       "\n",
       "Crossvalidation Results:\n",
       "\tk\tMSE\n",
-      "\t1\t1218.4976589426035\n",
-      "\t2\t842.5598738789062\n",
-      "\t3\t634.0396881925165\n",
-      "\t4\t487.58571842217555\n",
-      "\t5\t391.3888892988487\n",
-      "\t6\t305.3137200757752\n",
-      "\t7\t267.91129790103656\n",
-      "\t8\t243.05905296570523\n",
-      "\t9\t243.47674074722744\n",
-      "\t10\t245.6469865967401\n",
-      "\t11\t250.6216744074316\n",
-      "\t12\t253.98118656214808\n",
-      "\t13\t254.78915817386076\n",
-      "\t14\t255.89349140083132\n",
-      "\t15\t263.59632300410664\n",
-      "\t16\t269.0451615858919\n",
-      "\t17\t271.040578488372\n",
-      "\t18\t274.4169982210701\n",
-      "\t19\t279.30823157249597\n",
-      "\t20\t284.55829823829794\n",
+      "\t0\t1097.9822679456634\n",
+      "\t1\t639.948435659851\n",
+      "\t2\t639.948435659851\n",
+      "\t3\t491.31091160253413\n",
+      "\t4\t414.7982590934014\n",
+      "\t5\t307.63048180391786\n",
+      "\t6\t266.95374125278414\n",
+      "\t7\t242.0572267640577\n",
+      "\t8\t236.23211459381542\n",
+      "\t9\t243.58873069893227\n",
+      "\t10\t245.6937243742038\n",
+      "\t11\t246.44391892259432\n",
+      "\t12\t254.05026743790478\n",
+      "\t13\t256.2080803045909\n",
+      "\t14\t260.3857536819678\n",
+      "\t15\t260.5867303978344\n",
+      "\t16\t270.1163325764251\n",
+      "\t17\t275.10575084293146\n",
+      "\t18\t276.73604590979255\n",
+      "\t19\t280.43703442081045\n",
+      "\t20\t272.60846960582063\n",
       "\n",
       "Best k = 8\n",
       "\n",
-      "  5.162944 seconds (32.17 k allocations: 6.922 MiB)\n"
+      " 14.263994 seconds (30.21 M allocations: 7.031 GiB, 5.04% gc time)\n"
      ]
     }
    ],
    "source": [
     "Random.seed!(2020)\n",
-    "@time mses = cv_iht(y, xla, z);"
+    "@time mses = cv_iht(y, xla, z, path=0:20, init_beta=true);"
    ]
   },
   {
@@ -306,15 +339,15 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "Julia 1.5.0",
+   "display_name": "Julia 1.6.0",
    "language": "julia",
-   "name": "julia-1.5"
+   "name": "julia-1.6"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.5.0"
+   "version": "1.6.0"
   }
  },
  "nbformat": 4,

--- a/test/utilities_test.jl
+++ b/test/utilities_test.jl
@@ -3,7 +3,7 @@ function test_data(d, l)
     xla = SnpLinAlg{Float64}(x, model=ADDITIVE_MODEL, center=true, scale=true)
     z = ones(1000, 1)
     y = rand(1000)
-    v = IHTVariable(xla, z, y, 1, 10, d, l, Int[], Float64[], :none)
+    v = IHTVariable(xla, z, y, 1, 10, d, l, Int[], Float64[], :none, falses(1))
     MendelIHT.init_iht_indices!(v, false, trues(1000))
     return x, z, y, v
 end
@@ -11,7 +11,7 @@ end
 function make_IHTvar(d, μ, y)
     n = length(μ)
     v = IHTVariable(rand(n, 10), rand(n, 1), y, 1, 10, d, IdentityLink(),
-        Int[], Float64[], :none)
+        Int[], Float64[], :none, falses(1))
     MendelIHT.init_iht_indices!(v, false, trues(n))
     v.μ = μ
     return v
@@ -90,75 +90,6 @@ end
     @test all(isapprox(p, exp.(xb), atol=1e-8))
 end
 
-# @testset "update_xb! and check_covariate_supp!" begin
-#    	Random.seed!(1111)
-#     x, z, y, v = test_data(Normal(), IdentityLink())
-#     v.idx[1:10] .= trues(10)
-#     v.b .= rand(1000)
-#     tmp_x = convert(Matrix{Float64}, @view(x[:, v.idx]), center=true, scale=true)
-
-#     @test size(v.xk, 2) == 9 #IHTVariable is initialized to have k - 1 columns
-
-#     MendelIHT.check_covariate_supp!(v)
-
-#     @test size(v.xk, 2) == 10 
-
-#     MendelIHT.update_xb!(v)
-
-#     @test all(v.xb .≈ tmp_x * v.b[1:10])
-#     @test all(v.zc .== 0.0)
-#     @test all(abs.(v.b) .<= 30)
-# end
-
-# @testset "score!" begin
-#     # Not sure how to "really" test this function, so I'm throwing in a lot of input/outputs
-#     # as they are calculated right now, because the code seems to work well
-
-#     Random.seed!(1993)
-#     d = Normal()
-#     l = IdentityLink()
-#     (x, z, y, v) = test_data(d, l)
-#     score!(v)
-
-#     @test all(v.df[1:3] .≈ [8.057330896198419; -2.229495636684423; 9.948528223937274])
-#     @test v.df2[1] ≈ 500.8665816573597
-
-#     (x, z, y, v) = test_data(d, l)
-#     score!(v)
-
-#     @test all(v.df[1:3] .≈ [-12.569757729532215; 8.237144382138629; 9.625154193038197])
-#     @test v.df2[1] ≈ 503.8433996263735
-
-#     (x, z, y, v) = test_data(d, l)
-#     score!(v)
-
-#     @test all(v.df[1:3] .≈ [-2.2634046444623226; -5.266454260596382; -1.5449038662162529])
-#     @test v.df2[1] ≈ 507.55935638764254
-# end
-
-# @testset "_iht_gradstep!" begin
-#     Random.seed!(1111)
-
-#     x, z, y, v = test_data(Normal(), IdentityLink())
-#     v.b[1:3] .= [1; 2; 3]
-#     v.df[1:3] .= [1; 2; 3]
-#     b = copy(v.b)
-#     df = copy(v.df)
-#     J = 1
-#     k = 2
-#     η = 0.9
-#     v.k = k
-
-#     MendelIHT._iht_gradstep!(v, η) # this should keep 1 * 2 = 2 elements
-
-#     @test v.b[1] ≈ 0.0 # because first entry is smallest, it should be set to 0
-#     @test v.b[2] ≈ (b + η*df)[2]
-#     @test v.b[3] ≈ (b + η*df)[3]
-#     @test all(v.b[4:end] .≈ 0.0)
-#     @test all(v.c .≈ 0.0)
-#     @test all(v.df .≈ df)
-# end
-
 @testset "_choose!" begin
     J = 1
     k = 10
@@ -166,6 +97,7 @@ end
     Random.seed!(1111)
     x, z, y, v = test_data(Normal(), IdentityLink())
     fill!(v.idx, false)
+    fill!(v.idc, false)
     v.idx[1:10] .= trues(10)
     MendelIHT._choose!(v)
 
@@ -294,51 +226,4 @@ end
     @test all(1.0 .<= p .<= 2)
     @test p[1] ≈ 1 / (2.0sqrt(m[1] * (1 - m[1])))
     @test p[15] == 2.0
-end
-
-@testset "iht_stepsize!" begin
-    Random.seed!(1234)
-    d = Normal()
-    l = canonicallink(d)
-    x, z, y, v = test_data(d, l)
-    v.df .= rand(1000)
-    v.xk .= rand(size(v.xk, 1), size(v.xk, 2))
-    v.μ .= rand(1000)
-    fill!(v.idx, false)
-    v.idx[1:9] .= trues(9)
-
-    @test MendelIHT.iht_stepsize!(v) ≥ 0
-
-    d = Poisson()
-    l = canonicallink(d)
-    x, z, y, v = test_data(d, l)
-    v.df .= rand(1000)
-    v.xk .= rand(size(v.xk, 1), size(v.xk, 2))
-    v.μ .= rand(1000)
-    fill!(v.idx, false)
-    v.idx[1:9] .= trues(9)
-
-    @test MendelIHT.iht_stepsize!(v) ≥ 0
-
-    d = NegativeBinomial()
-    l = LogLink()
-    x, z, y, v = test_data(d, l)
-    v.df .= rand(1000)
-    v.xk .= rand(size(v.xk, 1), size(v.xk, 2))
-    v.μ .= rand(1000)
-    fill!(v.idx, false)
-    v.idx[1:9] .= trues(9)
-
-    @test MendelIHT.iht_stepsize!(v) ≥ 0
-
-    d = Bernoulli()
-    l = canonicallink(d)
-    x, z, y, v = test_data(d, l)
-    v.df .= rand(1000)
-    v.xk .= rand(size(v.xk, 1), size(v.xk, 2))
-    v.μ .= rand(1000)
-    fill!(v.idx, false)
-    v.idx[1:9] .= trues(9)
-
-    @test MendelIHT.iht_stepsize!(v) ≥ 0
 end


### PR DESCRIPTION
This PR:
+ Optionally includes covariates in sparsity projection, as opposed to always being subject to model selection (#37 )
+ Initializes nongenetic covariates to univariate values before regression
+ Update docs (FAQ and Examples)
+ Make PVE function callable externally

